### PR TITLE
finsihed the tile sorting toggle tool in left Ui tile tools

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -12,6 +12,8 @@
     "isometric-perspective.settings_dynamic_tile_hint": "(BETA FEATURE. USE WITH CAUTION) Adjusts the visibility of tiles dynamically with the positioning of tokens. See how this feature works here.",
     "isometric-perspective.settings_token_sort_name": "Enable Automatic Token Sorting",
     "isometric-perspective.settings_token_sort_hint": "(BETA FEATURE. USE WITH CAUTION. V12+ ONLY) Automatically adjusts the tokens sort property value when moving it around the canvas.",
+    "isometric-perspective.settings_toggle_depth_sort_active": "Toggle depth sort",
+    "isometric-perspective.settings_toggle_depth_sort_active_hint": "Toggle depth sort for newly created tiles while active.",
     "isometric-perspective.settings_token_silhouette_name": "Enable Occlusion: Token Silhouette",
     "isometric-perspective.settings_token_silhouette_hint": "(BETA FEATURE WITH PERFORMANCE ISSUES. USE SPARENTLY) Creates a shadow effect on the token when behind a tile. GPU mode isn't working properly, but it is lightning fast. CPU is always heavy in processing, but a higher chunk option is faster trading quality fidelity. 'Chunk Size = 2' is the probably the better mode.",
     "isometric-perspective.settings_welcome_name": "Show Welcome Screen",

--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -12,6 +12,8 @@
     "isometric-perspective.settings_dynamic_tile_hint": "(RECURSO EM TESTES. USE COM CUIDADO) Ajusta a visibilidade dos tiles dinamicamente com a posição dos tokens. Veja como esta funcionalidade funciona aqui.",
     "isometric-perspective.settings_token_sort_name": "Habilitar Ordenação Automática de Tokens",
     "isometric-perspective.settings_token_sort_hint": "(RECURSO EM TESTES. USE COM CUIDADO. SOMENTE PARA V12+) Ajusta automaticamente o valor de ordenação dos tokens ao movê-los pelo canvas.",
+    "isometric-perspective.settings_toggle_depth_sort_active": "Toggle depth sort",
+    "isometric-perspective.settings_toggle_depth_sort_active_hint": "Toggle depth sort for newly created tiles while active.", 
     "isometric-perspective.settings_token_silhouette_name": "Habilitar Oclusão: Silhueta de Token",
     "isometric-perspective.settings_token_silhouette_hint": "(RECURSO EM TESTES COM PROBLEMAS DE PERFORMANCE. USE DE FORMA LEVE) Cria um efeito de sombra sobre o token que estiver por trás de um tile. GPU não está funcionando corretamente, mas é super rápido. CPU é sempre pesado no processamento, mas é possível diminuir o impacto escolhendo um valor de chunk maior. 'Chunk Size = 2' é provavelmente a melhor opção.",
     "isometric-perspective.settings_welcome_name": "Mostrar Janela de Boas-Vindas",

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -118,6 +118,16 @@ Hooks.once("init", function() {
     requiresReload: true
   });
 
+  game.settings.register(isometricModuleConfig.MODULE_ID, "depthSortActiveFlag", {
+    name: game.i18n.localize('isometric-perspective.settings_toggle_depth_sort_active'), //name: 'Toggle depth sorting',
+    hint: game.i18n.localize('isometric-perspective.settings_toggle_depth_sort_active_hint'), //hint: 'Toggle depth sorting for newly created tiles while active',
+    scope: 'world',
+    config: false,
+    default: false,
+    type: Boolean,
+    requiresReload: false
+  });
+
   /*
   game.settings.register(isometricModuleConfig.MODULE_ID, 'enableOcclusionTokenSilhouette', {
     name: game.i18n.localize('isometric-perspective.settings_token_silhouette_name'), //name: 'Enable Occlusion: Token Silhouette',
@@ -255,7 +265,9 @@ Hooks.on("renderTileConfig", initTileForm);
 Hooks.on("createTile", handleCreateTile);
 Hooks.on("updateTile", handleUpdateTile);
 Hooks.on("refreshTile", handleRefreshTile);
-Hooks.on("getSceneControlButtons", addDepthSortControls);
+Hooks.on("getSceneControlButtons", controls => {
+  addDepthSortControls(controls);
+});
 
 //autosorting
 Hooks.on("init", () => {

--- a/scripts/tile.js
+++ b/scripts/tile.js
@@ -93,6 +93,13 @@ export function handleCreateTile(tileDocument) {
   const scene = tile.scene;
   const isSceneIsometric = scene.getFlag(isometricModuleConfig.MODULE_ID, "isometricEnabled");
   requestAnimationFrame(() => applyIsometricTransformation(tile, isSceneIsometric));
+
+  const isDepthSortToggled = game.settings.get(isometricModuleConfig.MODULE_ID, "depthSortActiveFlag");
+  if(isDepthSortToggled){
+    tile.document.setFlag(isometricModuleConfig.MODULE_ID,"isoTileAutoSortingEnabled", true);
+  } else {
+    tile.document.setFlag(isometricModuleConfig.MODULE_ID,"isoTileAutoSortingEnabled", false);
+  }
 }
 
 export function handleUpdateTile(tileDocument, updateData, options, userId) {
@@ -134,14 +141,15 @@ export function handleRefreshTile(tile) {
 }
 
 export function addDepthSortControls(controls){
-  controls.tiles.tools.toggleDetphSort = {
-    name:" toggle depth sort",
+  controls.tiles.tools.toggleDephtSort = {
+    name:"toggleDephtSort",
+    title:"Toggle depth sort",
     icon: "fa-solid fa-sort",
-    order: Object.keys(controls.tokens.tools).length,
-    button: true,
+    order: Object.keys(controls.tiles.tools).length,
+    toggle: true,
     visible: game.user.isGM,
-    onChange: () => {
-      // game.settings.get(isometricModuleConfig.MODULE_ID, "toggleTileDepthSort")
+    onChange: (event,toggled) => {
+      game.settings.set(isometricModuleConfig.MODULE_ID, "depthSortActiveFlag",toggled);
     }
   }
 }

--- a/templates/tile-config.hbs
+++ b/templates/tile-config.hbs
@@ -4,11 +4,11 @@
         <label for="{{rootId}}-isometric-perspective-enable-tile-enable-isometrics">{{localize 'isometric-perspective.tile_enableIsometric_name'}}</label>
         <input id="{{rootId}}-isometric-perspective-enable-tile-enable-isometrics" type="checkbox" name="flags.isometric-perspective.isoTileDisabled" {{checked document.flags.isometric-perspective.isoTileDisabled}}>
     </div>
-        <div class="form-group">
+    <p class="hint">{{localize 'isometric-perspective.tile_enableIsometric_hint'}}</p>
+    <div class="form-group">
         <label for="{{rootId}}-isometric-perspective-enable-tile-enable-isometrics-tile-sorting">{{localize 'isometric-perspective.tile_enableIsometric_sorting_name'}}</label>
         <input id="{{rootId}}-isometric-perspective-enable-tile-enable-isometrics-tile-sorting" type="checkbox" name="flags.isometric-perspective.isoTileAutoSortingEnabled" {{checked document.flags.isometric-perspective.isoTileAutoSortingEnabled}}>
     </div>
-    <p class="hint">{{localize 'isometric-perspective.tile_enableIsometric_hint'}}</p>
     <div class="form-group offset-point">
         <label>{{localize 'isometric-perspective.tile_artOffset_name'}}</label>
         <div class="form-fields">


### PR DESCRIPTION
finalized the tile control tool that while toggled, tiles are created with the depth sort option enabled ( and checked in their config ) 
this is a needed QOL for this feature to be worth using