### PR TITLE
Warpspeednyancat v14 update

### DIFF
--- a/scripts/autosorting.js
+++ b/scripts/autosorting.js
@@ -9,10 +9,13 @@ export function isoDepthSortMixin(Base){
   return class DepthSortPlaceable extends Base{
     _refreshState() {
       super._refreshState();
-      if (this.document.documentName === "Tile"){
+      if (this !== null && this.document.documentName === "Tile"){
         const isTileSortable = this.document.flags[isometricModuleConfig.MODULE_ID]?.isoTileAutoSortingEnabled || false;
-        if (isTileSortable){ this.mesh.sortLayer = foundry.canvas.groups.PrimaryCanvasGroup.SORT_LAYERS.TOKENS; 
-        } else { this.mesh.sortLayer = foundry.canvas.groups.PrimaryCanvasGroup.SORT_LAYERS.TILES; }
+        if (isTileSortable){ 
+          this.mesh.sortLayer = foundry.canvas.groups.PrimaryCanvasGroup.SORT_LAYERS.TOKENS; 
+        } else { 
+          this.mesh.sortLayer = foundry.canvas.groups.PrimaryCanvasGroup.SORT_LAYERS.TILES; 
+        }
       }
       this.zIndex = 0;
       this.mesh.zIndex = 0;
@@ -21,20 +24,23 @@ export function isoDepthSortMixin(Base){
     }
     _onUpdate(changed, options, userId) {
       super._onUpdate(changed, options, userId);
-      let currentRegionOnMovementEnd = null;
+
+      let currentOccupiedRegion = null;
+
       if (this.document.documentName === "Token"){
-        // const currentRegions = this.document.regions;
         if ("_regions" in changed) {
           const priorRegions = options._priorRegions?.[this.document.id]?.map(id => this.document.parent.regions.get(id));
           const currentRegions = this.document.regions;
           const newlyEnteredRegions = currentRegions.filter(region => !priorRegions.includes(region));
           const currentRegionEnd = Array.from(newlyEnteredRegions).map(region => region);
-          currentRegionOnMovementEnd = currentRegionEnd[0]?.flags[isometricModuleConfig.MODULE_ID]?.isoRegionTilesAutoSortingEnabled;
+          if (currentRegionEnd !== undefined && currentRegionEnd !== null && currentRegionEnd[0]?.flags[isometricModuleConfig.MODULE_ID]?.isoRegionTilesAutoSortingEnabled){
+            currentOccupiedRegion = currentRegionEnd
+          }
         }
       }
       // prevent sorting when the y coordinates of a placeable didnt change ( thanks Michael for the tip! )
       if ("y" in changed) {
-        sortPlaceablePosition(this, currentRegionOnMovementEnd);
+        sortPlaceablePosition(this, currentOccupiedRegion);
       }
     }
   }

--- a/scripts/autosorting.js
+++ b/scripts/autosorting.js
@@ -21,7 +21,7 @@ export function isoDepthSortMixin(Base){
     }
     _onUpdate(changed, options, userId) {
       super._onUpdate(changed, options, userId);
-
+      let currentRegionOnMovementEnd = null;
       if (this.document.documentName === "Token"){
         // const currentRegions = this.document.regions;
         if ("_regions" in changed) {
@@ -29,16 +29,17 @@ export function isoDepthSortMixin(Base){
           const currentRegions = this.document.regions;
           const newlyEnteredRegions = currentRegions.filter(region => !priorRegions.includes(region));
           const currentRegionEnd = Array.from(newlyEnteredRegions).map(region => region);
-          console.log("current region? : " , currentRegionEnd[0]?.name, console.log("changed?",changed))
+          currentRegionOnMovementEnd = currentRegionEnd[0]?.flags[isometricModuleConfig.MODULE_ID]?.isoRegionTilesAutoSortingEnabled;
         }
       }
       // prevent sorting when the y coordinates of a placeable didnt change ( thanks Michael for the tip! )
       if ("y" in changed) {
-        sortPlaceablePosition(this);
+        sortPlaceablePosition(this, currentRegionOnMovementEnd);
       }
     }
   }
 }
+
 
 /**
  * Waits for a token's movement animation to complete.

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -23,7 +23,7 @@ import {
    createRegionIsometricTab,
    initRegionForm,
    handleUpdateRegion,
-   testRegionInteract
+  //  testRegionInteract
  } from './regions.js'
 
 import { 
@@ -260,9 +260,9 @@ Hooks.on('renderPrototypeTokenConfig', initTokenForm);
 Hooks.on("createToken", handleCreateToken);
 Hooks.on("updateToken", handleUpdateToken);
 Hooks.on("refreshToken", handleRefreshToken);
-Hooks.on("stopToken", (data)=>{
-  console.log("DATA:", data)
-});
+// Hooks.on("stopToken", (data)=>{
+//   console.log("DATA:", data)
+// });
 
 // hud management
 Hooks.on("renderTokenHUD", handleRenderTokenHUD);
@@ -283,7 +283,7 @@ Hooks.on("getSceneControlButtons", controls => {
 Hooks.on("ready", createRegionIsometricTab);
 Hooks.on("renderRegionConfig", initRegionForm);
 Hooks.on("updateRegion", handleUpdateRegion);
-Hooks.on("tokenMoveWithin", testRegionInteract);
+// Hooks.on("tokenMoveWithin", testRegionInteract);
 
 //autosorting
 Hooks.on("init", () => {

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -119,7 +119,7 @@ export function isIsometricAutosortingEnabledForPlaceable(placeable,scene) {
  * change placeables sort values based on its y value on the grid compared to its siblings.
  * @param {Placeable|PlaceableDocument} token - The token or token document to calculate for.
  */
-export function sortPlaceablePosition(placeable, isRegionOnMovementEnd = null) {
+export function sortPlaceablePosition(placeable, currentOccupiedRegion = null) {
   if(placeable.mesh.sortLayer === foundry.canvas.groups.PrimaryCanvasGroup.SORT_LAYERS.TOKENS ){
     const placeableMeshLayer = foundry.canvas.groups.PrimaryCanvasGroup.SORT_LAYERS.TOKENS;
     const canvasLayer = canvas.primary.children;
@@ -127,19 +127,11 @@ export function sortPlaceablePosition(placeable, isRegionOnMovementEnd = null) {
     const displayList = [];
     canvasLayer.map(sprite => {
       if(sprite.sortLayer === placeableMeshLayer){
-        const placeableId = placeable.document.id
-        const currentSprite = {
-          type:sprite.object.document.documentName,
-          y: sprite.object.document.y,
-          height:sprite.object.document.height
-        }
-        //v14 compatibility fix
-        if (game.release.generation >= 14) { if(currentSprite.type === "Tile"){ currentSprite.y = currentSprite.y + (currentSprite.height * 0.5);}}
         displayList.push(sprite);
       }
     });
 
-    displayList.sort((sprite,sibling)=> { return sprite.object.document.y - sibling.object.document.y})
+    displayList.sort((sprite,sibling)=> compareSpritePosition(sprite,sibling)) // compare function should be improved
 
     for (let i = 0; i < displayList.length; i++) {
       const currentSprite = displayList[i];
@@ -148,6 +140,42 @@ export function sortPlaceablePosition(placeable, isRegionOnMovementEnd = null) {
     }
     placeable.mesh.parent.sortDirty = true;
   }
+}
+
+function compareSpritePosition(sprite,sibling){    
+  let result = 0;
+
+  const currentSprite = {
+    type:sprite.object.document.documentName,
+    y: sprite.object.document.y,
+    height:sprite.object.document.height,
+  }
+
+  const currentSibling = {
+    type:sibling.object.document.documentName,
+    y: sibling.object.document.y,
+    height:sprite.object.document.height,
+  }
+   
+  if (currentSprite.type === "Tile"){
+    if (game.release.generation < 14) { //v14 compatibility fix
+      currentSprite.y = currentSprite.y - (currentSprite.height*0.5);
+    }
+  }
+
+  if (currentSibling.type === "Tile"){
+    if (game.release.generation < 14) { //v14 compatibility fix
+      currentSibling.y = currentSibling.y - (currentSibling.height*0.5);
+    }
+  }
+
+  if (currentSprite.y > currentSibling.y) {
+    result = 1;
+  } else if (currentSprite.y < currentSibling.y) {
+    result = -1;
+  }
+
+  return result;
 }
 
 /**
@@ -306,4 +334,14 @@ export function createAdjustableButton(options) {
       e.preventDefault();
       e.stopPropagation();
   });
+}
+
+export function graphicDebugTool(x,y,container){
+  const dot = new PIXI.Graphics();
+  dot.drawRect(2000,2000,200,200);
+  // dot.drawRect(x,y,200,200);
+  dot.visible = true;
+  dot.beginFill(0xff0000)
+  dot.endFill();
+  container.addChild(dot);
 }

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -119,7 +119,7 @@ export function isIsometricAutosortingEnabledForPlaceable(placeable,scene) {
  * change placeables sort values based on its y value on the grid compared to its siblings.
  * @param {Placeable|PlaceableDocument} token - The token or token document to calculate for.
  */
-export function sortPlaceablePosition(placeable) {
+export function sortPlaceablePosition(placeable, isRegionOnMovementEnd = null) {
   if(placeable.mesh.sortLayer === foundry.canvas.groups.PrimaryCanvasGroup.SORT_LAYERS.TOKENS ){
     const placeableMeshLayer = foundry.canvas.groups.PrimaryCanvasGroup.SORT_LAYERS.TOKENS;
     const canvasLayer = canvas.primary.children;


### PR DESCRIPTION
forgot to unshtash like an idiot ...

so i polished further the sort logic to begin including region sort logic
so if a token on movement end end up on a region it can end the region's linked tile id to the depth sort logic 

later , that logic can  then compare theses id's to the sibling tiles ,  if any of theses tiles share an id on that list, theses tiles will have always sort on top, otherwise sortnormally
then a gm can draw theses regions , enable the functionality , link tiles and when tokens step on them it will trigger the sort logic 

possible improvements :

- add an opacity slider to the region config, tiles linked to that region will fade to that opacity level when triggered.
- link tiles positions relative to the region shape , when the shape is moved , this will cause the shape to act as a "room template" , tiles could still move independantly on their own t be adjusted .
