### PR TITLE
Warpspeednyancat v14 update

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -65,6 +65,8 @@
     "isometric-perspective.tile_enableIsometric_sorting_hint": "Enable tile depth sorting on this tile.",
     "isometric-perspective.tile_artOffset_name": "Art Offset",
     "isometric-perspective.tile_artOffset_hint": "Offset the tile art position in pixels.",
+    "isometric-perspective.tile_enableIsometric_anchor_gizmo": "Enable art offset gizmo",
+    "isometric-perspective.tile_enableIsometric_anchor_gizmo_hint": "Display an alignment gizmo centered on the tile anchor point to give a better idea of where a tile should be offset if needed",
     "isometric-perspective.tile_artOffset_mouseover": "Hold and drag to fine-tune X and Y",
     "isometric-perspective.tile_scale_name": "Isometric Scale",
     "isometric-perspective.tile_scale_hint": "Adjust scale of tile art when in isometric perspective (0.01x to 3x).",
@@ -80,12 +82,11 @@
     "isometric-perspective.tile_decoupleScale_hint": "If checked, the tile will not auto-resize its art when its dimensions change.",
 
     "isometric-perspective._comment": "Region Configuration",
-    "isometric-perspective.region_enableIsometric_room_sorting_name": "Enable region room depth sorting",
-    "isometric-perspective.region_enableIsometric_room_sorting_hint": "Sort linked tiles as front or back walls when tokens interact with this region",
+    "isometric-perspective.region_enableIsometric_room_sorting_name": "Enable depth sorting by linking tiles to this region.",
+    "isometric-perspective.region_enableIsometric_room_sorting_hint": "Sort linked tiles as back walls when tokens interact with this region",
     "isometric-perspective.region_link_tile_name": "Link Tiles",
     "isometric-perspective.region_link_tile_select_tile": "Select Tiles",
     "isometric-perspective.region_link_tile_clear_tile": "Clear Tiles",
-    "isometric-perspective.region_link_front_tiles_hint": "Select tiles to mark them as a room's front walls, theses tiles will be depth sorted above tokens if tokens are within the region boundaries",
     "isometric-perspective.region_link_back_tiles_hint": "Select tiles to mark them as a room's back walls, theses tiles will be depth sorted below tokens if tokens are within the region boundaries",
     
     "isometric-perspective._comment": "Warnings and Error Messages",

--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -65,6 +65,8 @@
     "isometric-perspective.tile_enableIsometric_sorting_hint": "Ative a classificação por profundidade de mosaico neste mosaico.",
     "isometric-perspective.tile_artOffset_name": "Deslocamento da Arte",
     "isometric-perspective.tile_artOffset_hint": "Desloca a posição da arte do tile no número de pixels indicado.",
+    "isometric-perspective.tile_enableIsometric_anchor_gizmo": "Ativar gizmo de deslocamento de arte",
+    "isometric-perspective.tile_enableIsometric_anchor_gizmo_hint": "Exiba um indicador de alinhamento centralizado no ponto de ancoragem do bloco para dar uma ideia melhor de onde um bloco deve ser deslocado, se necessário.",
     "isometric-perspective.tile_artOffset_mouseover": "Segure e arraste para ajustar X e Y",
     "isometric-perspective.tile_scale_name": "Escala Isométrica",
     "isometric-perspective.tile_scale_hint": "Ajusta a escala da arte do tile no modo isométrico (0.01x a 3x).",
@@ -76,6 +78,14 @@
     "isometric-perspective.tile_link_wall_select_wall": "Selecionar Parede",
     "isometric-perspective.tile_link_wall_clear_wall": "Limpar Parede",
     "isometric-perspective.tile_link_wall_hint": "Clique no botão para selecionar uma parede. Ela será usada para determinar a visibilidade do tile com um token selecionado.",
+
+    "isometric-perspective._comment": "Configuração de região",
+    "isometric-perspective.region_enableIsometric_room_sorting_name": "Ative a classificação por profundidade vinculando os mosaicos a esta região.",
+    "isometric-perspective.region_enableIsometric_room_sorting_hint": "Classifique os blocos vinculados como paredes de fundo quando os tokens interagirem com esta região.",
+    "isometric-perspective.region_link_tile_name": "Blocos de tiles",
+    "isometric-perspective.region_link_tile_select_tile": "Selecione os blocos",
+    "isometric-perspective.region_link_tile_clear_tile": "Azulejos tiles",
+    "isometric-perspective.region_link_back_tiles_hint": "Selecione os ladrilhos para marcá-los como paredes de fundo de uma sala; esses ladrilhos serão classificados por profundidade abaixo dos marcadores, caso os marcadores estejam dentro dos limites da região.",
 
     "isometric-perspective._comment": "Avisos e Mensagens de Erro",
     "isometric-perspective.error_test": "Mensagem de erro de teste",

--- a/scripts/autosorting.js
+++ b/scripts/autosorting.js
@@ -69,7 +69,7 @@ export function isoDepthSortTokenMixin(Base){
         currentSprite.object.document.sort = i;
         currentSprite.sort = i;
       }
-      // debugCanvasLayer(this.sortList)
+      debugCanvasLayer(this.sortList)
       this.mesh.parent.sortDirty = true;
     }
 

--- a/scripts/autosorting.js
+++ b/scripts/autosorting.js
@@ -53,17 +53,23 @@ export function isoDepthSortTokenMixin(Base){
       this.zIndex = 0;
       this.mesh.zIndex = 0;
 
-        // if ( this.document.getFlag(isometricModuleConfig.MODULE_ID, 'currentRegion')) { // to decomment when sortByRegion works
-        //   this.sortList = sortPlaceableByRegion(this);
-        // } else {
-          this.sortList = sortPlaceableByPosition(this);
-        // }
+        const currentRegions = Array.from(this.document.regions).map(region => region);
+        const currentRegion = currentRegions[0]?._id;
+        if(currentRegion){
+          console.log("currentRegion",currentRegion)
+          this.document.setFlag(isometricModuleConfig.MODULE_ID, 'currentRegion', currentRegion);
+        } else {
+          this.document.setFlag(isometricModuleConfig.MODULE_ID, 'currentRegion', null);
+        }
+
+      this.sortList = sortPlaceableByPosition(this);
+
       for (let i = 0; i < this.sortList.length; i++) {
         const currentSprite = this.sortList[i];
         currentSprite.object.document.sort = i;
         currentSprite.sort = i;
       }
-      debugCanvasLayer(this.sortList)
+      // debugCanvasLayer(this.sortList)
       this.mesh.parent.sortDirty = true;
     }
 
@@ -72,9 +78,7 @@ export function isoDepthSortTokenMixin(Base){
       this.zIndex = 0;
       this.mesh.zIndex = 0;
       if ("y" in changed || "x" in changed) {
-        const currentRegions = Array.from(this.document.regions).map(region => region);
-        const currentRegion = currentRegions[0]?._id;
-        this.document.setFlag(isometricModuleConfig.MODULE_ID, 'currentRegion', currentRegion);
+        // later use this to prevent unecessary updates
       }
     }
   }

--- a/scripts/autosorting.js
+++ b/scripts/autosorting.js
@@ -42,7 +42,7 @@ export function isoDepthSortTokenMixin(Base){
   return class DepthSortPlaceable extends Base{
     sortList = [];
     /** 
-     * notable observations : a single token move by one square trigger _refreshState() up to 5 times , 
+     * note: a single token move by one square trigger _refreshState() up to 5 times , 
      * and a lot of other _onUpdate() can fire in between, _onUpdate() is usually one step behind _refreshState()
      * _onUpdate()  and _refreshState() should never get mutual triggering code execution , otherwhise this cause an endless loop
      * be warned! this will make your pc fan scream in pain!

--- a/scripts/regions.js
+++ b/scripts/regions.js
@@ -86,7 +86,7 @@ export function initRegionForm(app, html, context, options){
     canvasLayer.filter(children => children.object?.document?.getFlag(isometricModuleConfig.MODULE_ID, 'regionLink'))
     .filter( tile => tile.object.document.getFlag(isometricModuleConfig.MODULE_ID, 'regionLink') === app.document.id)
     .map( tile => {
-      tile.object.document.setFlag(isometricModuleConfig.MODULE_ID, 'regionLink', []);
+      tile.object.document.setFlag(isometricModuleConfig.MODULE_ID, 'regionLink', null);
     })
 
     await app.document.setFlag(isometricModuleConfig.MODULE_ID, 'linkedTilesIds', []);

--- a/scripts/tile.js
+++ b/scripts/tile.js
@@ -5,6 +5,7 @@ import {
   parseNum, 
   patchConfig, 
   createAdjustableButton,
+  toggleAnchorAxis,
 } from './utils.js';
 
 export async function createTileIsometricTab(app, html, data) {
@@ -43,11 +44,26 @@ export function initTileForm(app, html, context, options){
   const selectWallButton = html.querySelector('.select-wall');
   const clearWallButton = html.querySelector('.clear-wall');
   const linkedWallsIdInput = html.querySelector('input[name="flags.isometric-perspective.linkedWallIds"]');
+  const gizmoEnabledCheckbox = html.querySelector('input[name="flags.isometric-perspective.isoOffsetGizmoEnabled"]');
 
   // Initialize values
   const currentOffsetX = app.document.getFlag(isometricModuleConfig.MODULE_ID, 'offsetX');
   const currentOffsetY = app.document.getFlag(isometricModuleConfig.MODULE_ID, 'offsetY');
   const currentScale = app.document.getFlag(isometricModuleConfig.MODULE_ID, 'scale');
+
+
+  // Art offset
+  gizmoEnabledCheckbox.addEventListener('change', (event) => {
+    const tileDocument = context.document;
+    if(event.target.checked){
+      tileDocument.setFlag(isometricModuleConfig.MODULE_ID,"isoOffsetGizmoEnabled", true);
+      console.log("tileDocument", tileDocument)
+      toggleAnchorAxis(tileDocument,true);
+    } else {
+      tileDocument.setFlag(isometricModuleConfig.MODULE_ID,"isoOffsetGizmoEnabled", false);
+      toggleAnchorAxis(tileDocument,false);
+    }
+  }) 
 
   const inputOffsetX = html.querySelector('input[name="flags.isometric-perspective.offsetX"]');
   const inputOffsetY = html.querySelector('input[name="flags.isometric-perspective.offsetY"]');
@@ -123,12 +139,20 @@ export function handleUpdateTile(tileDocument, updateData, options, userId) {
     requestAnimationFrame(() => applyIsometricTransformation(tile, isSceneIsometric));
   }
 
+  if (tileDocument.getFlag(isometricModuleConfig.MODULE_ID,"isoOffsetGizmoEnabled") === true){
+    toggleAnchorAxis(tileDocument,true);
+  }
+
 }
 
 export function handleRefreshTile(tile) {
   const scene = tile.scene;
   const isSceneIsometric = scene.getFlag(isometricModuleConfig.MODULE_ID, "isometricEnabled");
   applyIsometricTransformation(tile, isSceneIsometric);
+
+  if (tile.document.getFlag(isometricModuleConfig.MODULE_ID,"isoOffsetGizmoEnabled") === true){
+    toggleAnchorAxis(tile.document,true);
+  }
 
 }
 

--- a/scripts/tile.js
+++ b/scripts/tile.js
@@ -1,6 +1,11 @@
 import { isometricModuleConfig } from './consts.js';
 import { applyIsometricTransformation } from './transform.js';
-import { adjustInputWithMouseDrag, parseNum, patchConfig, createAdjustableButton} from './utils.js';
+import { 
+  adjustInputWithMouseDrag, 
+  parseNum, 
+  patchConfig, 
+  createAdjustableButton,
+} from './utils.js';
 
 export async function createTileIsometricTab(app, html, data) {
 
@@ -66,13 +71,15 @@ export function initTileForm(app, html, context, options){
 
     Hooks.once('controlWall', async (wall) => {
       const selectedWallId = wall.id.toString();
-      const currentWallIds = app.document.getFlag(isometricModuleConfig.MODULE_ID, 'linkedWallIds') || [];
+      // const currentWallIds = app.document.getFlag(isometricModuleConfig.MODULE_ID, 'linkedWallIds') || [];
+      const flagIds = tile.document.getFlag("isometric-perspective", 'linkedWallIds') || [];
+      const currentWallIds = [].concat(flagIds);
       
       // Add the new ID only if it is not already in the list.
       if (!currentWallIds.includes(selectedWallId)) {
         const newWallIds = [...currentWallIds, selectedWallId];
         await app.document.setFlag(isometricModuleConfig.MODULE_ID, 'linkedWallIds', newWallIds);
-        if (linkedWallsIdInput) linkedWallsIdInput.value = newWallIds.join(", ");
+        // if (linkedWallsIdInput) linkedWallsIdInput.value = newWallIds.join(", ");
       }
 
       // Returns the window to its original position and activates the TileLayer layer.

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -164,13 +164,26 @@ function compareSpriteByPosition(sprite,sibling){
   let sortChange = 0;
   const currentSprite = sortableSprite(sprite);
   const currentSibling = sortableSprite(sibling);
-    if(currentSprite.tileMirrorHorizontal || currentSprite.tileFlipped || currentSibling.tileMirrorHorizontal || currentSibling.tileFlipped){
-      sortChange = sortByY(currentSprite,currentSibling);
-    } else if(isRegionMatching(currentSprite,currentSibling)){ // still flickering
+
+  if(isRegionMatching(currentSprite,currentSibling)){
+    if(currentSprite.type === "Tile"){
       sortChange = -1;
+    } else if (currentSibling.type === "Tile"){
+      sortChange = 1;
+    }
+  } else {
+    if(currentSprite.tileMirrorHorizontal || currentSprite.tileFlipped || currentSibling.tileMirrorHorizontal || currentSibling.tileFlipped){
+      if(currentSprite.type === "Tile"){drawTileAnchorLines(currentSprite)}
+      if(currentSibling.type === "Tile"){drawTileAnchorLines(currentSprite)}
+
+      sortChange = sortByY(currentSprite,currentSibling);
     } else {
+      if(currentSprite.type === "Tile"){drawTileAnchorLines(currentSprite)}
+      if(currentSibling.type === "Tile"){drawTileAnchorLines(currentSprite)}
+
       sortChange = sortByX(currentSprite,currentSibling);
     }
+  }
   return sortChange;
 }
 
@@ -187,7 +200,6 @@ function sortByY(spriteA , spriteB){
   return result;
 }
 
-// still not sure if that works
 function isRegionMatching (sprite, sibling){
   if(sprite.occupiedRegion !== null && sibling.linkedRegion !== null){
     if(sprite.occupiedRegion === sibling.linkedRegion){return true}
@@ -318,43 +330,101 @@ export function createAdjustableButton(options) {
   });
 }
 
+function toggleAnchorAxis(object,toggle){
+  cleanupTileAnchorLines()
+  if(toggle){
+    drawTileAnchorLines(object)
+  }
+}
+
 // used to debug visually a point on the tile selection box's footprint but its bugged, should fix later
-// export function graphicDebugTool(x,y,container){
-//   const dot = new PIXI.Graphics();
-//   dot.drawRect(2000,2000,200,200);
-//   // dot.drawRect(x,y,200,200);
-//   dot.visible = true;
-//   dot.beginFill(0xff0000)
-//   dot.endFill();
-//   container.addChild(dot);
-// }
+function drawTileAnchorLines(objectAnchor) {
+  // Removes existing lines
+  cleanupTileAnchorLines();
+  
+  // Create container for the lines
+  const xAxisLine = new PIXI.Graphics();
+  xAxisLine.name = 'anchorLine';
+  xAxisLine.lineStyle(2, 0x0000FF, 0.75); // line width, color, opacity
+
+  const yAxisLine = new PIXI.Graphics();
+  yAxisLine.name = 'anchorLine';
+  yAxisLine.lineStyle(2, 0xFF0000, 0.75); // line width, color, opacity
+
+  const zAxisLine = new PIXI.Graphics();
+  zAxisLine.name = 'anchorLine';
+  zAxisLine.lineStyle(2, 0x00FF00, 0.75); // line width, color, opacity
+
+  // Calculate diagonal length
+  const canvasWidth = canvas.dimensions.width;
+  const canvasHeight = canvas.dimensions.height;
+  const diagonalLength = Math.sqrt(Math.pow(canvasWidth, 2) + Math.pow(canvasHeight, 2));
+
+  //horizontal lines
+  xAxisLine.moveTo(objectAnchor.x, objectAnchor.y - diagonalLength / 2);
+  xAxisLine.lineTo(objectAnchor.x, objectAnchor.y + diagonalLength / 2);
+  yAxisLine.moveTo(objectAnchor.x - diagonalLength / 2, objectAnchor.y);
+  yAxisLine.lineTo(objectAnchor.x + diagonalLength / 2, objectAnchor.y);
+  
+  // vertical line
+  zAxisLine.moveTo(objectAnchor.x, objectAnchor.y);
+  zAxisLine.lineTo(objectAnchor.x + diagonalLength / 2, objectAnchor.y - diagonalLength / 2);
+
+  // Add on canvas
+  canvas.stage.addChild(xAxisLine);
+  canvas.stage.addChild(yAxisLine);
+  canvas.stage.addChild(zAxisLine);
+};
+
+function cleanupTileAnchorLines() {
+  const existingLines = canvas.stage.children.filter(child => child.name === 'anchorLine');
+  existingLines.forEach(line => line.destroy());
+};
+
+
+/**
+ * // a factory function that return a new object that contain all the relevant data required for depth sorting
+ * @param {*} sprite 
+ * @returns 
+ */
 
 function sortableSprite(sprite){
   // may seems overkill but passing the values directly sometimes cause weird "in between" value mutations that bricks sorting calculations
+  // also can prepare the data based on some conditions or states, for example the right offset of tiles might change if a tile is flipped or not
+
   const id = sprite.object.document.id;
   const type = sprite.object.document.documentName;
   const name = sprite.object.document.name? sprite.object.document.name : "no name";
-  let adjustedX = sprite.object.document.x;
-  let adjustedY = sprite.object.document.y;
+  const x = sprite.object.document.x;
+  const y = sprite.object.document.y;
+  let anchorX = sprite.object.document.x;
+  let anchorY = sprite.object.document.y;
+  const tileMirrorHorizontal = sprite.object.document.getFlag(fastFlipCompatiility.MODULE_ID, fastFlipCompatiility.TILE_MIRROR_HORIZONTAL)?sprite.object.document.getFlag(fastFlipCompatiility.MODULE_ID, fastFlipCompatiility.TILE_MIRROR_HORIZONTAL) : null;
+  const tileFlipped = sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID, 'tileFlipped')?sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID,'tileFlipped') : null;
+
+  // console.log("sprite isoAnchorX", sprite.object.document)
+
   if(sprite.object.document.documentName === "Tile"){
-    adjustedX = (sprite.object.document.x) - (sprite.object.document.width * 0.5);
-    adjustedY = (sprite.object.document.y) + (sprite.object.document.height * 0.25);
+    anchorX = (sprite.object.document.x) - (sprite.object.document.width * 0.5);
+    anchorY = (sprite.object.document.y) + (sprite.object.document.height * 0.5);
   }
+
   const height = sprite.object.document.height;
   const width = sprite.object.document.width;
   let newLinkedRegion = sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID, 'regionLink');
   let newOccupiedRegion = sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID, 'currentRegion');
   if(!newLinkedRegion){newLinkedRegion = null};
   if(!newOccupiedRegion){newOccupiedRegion = null};
-  const tileMirrorHorizontal = sprite.object.document.getFlag(fastFlipCompatiility.MODULE_ID, fastFlipCompatiility.TILE_MIRROR_HORIZONTAL)?sprite.object.document.getFlag(fastFlipCompatiility.MODULE_ID, fastFlipCompatiility.TILE_MIRROR_HORIZONTAL) : null;
-  const tileFlipped = sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID, 'tileFlipped')?sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID,'tileFlipped') : null;
+  
 
   return {
     id:id,
     type:type,
     name: name,
-    x: adjustedX,
-    y: adjustedY,
+    x: x,
+    y: y,
+    anchorX: anchorX,
+    anchorY: anchorY,
     height:height,
     width:width,
     forceSortBelow: false,
@@ -371,11 +441,11 @@ export function debugCanvasLayer(spriteList){
     const data = []
 
     spriteList.map(sprite => {
-      let adjustedX = sprite.object.document.x;
-      let adjustedY = sprite.object.document.y;
+      let anchorX = sprite.object.document.x;
+      let anchorY = sprite.object.document.y;
       if(sprite.object.document.documentName === "Tile"){
-        adjustedX = (sprite.object.document.x) - (sprite.object.document.width * 0.5)
-        adjustedY = (sprite.object.document.y) + (sprite.object.document.height * 0.25)
+        anchorX = (sprite.object.document.x) - (sprite.object.document.width * 0.5)
+        anchorY = (sprite.object.document.y) + (sprite.object.document.height * 0.25)
       }
 
       let newLinkedRegion = sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID, 'regionLink');
@@ -387,8 +457,8 @@ export function debugCanvasLayer(spriteList){
         // type: sprite.object.document.documentName,
         name: sprite.object.document.name? sprite.object.document.name : "no name",
         //sprite.documentName === "Tile"? (sprite.x) - (sprite.width *0.25) : sprite.x,
-        // x: adjustedX,
-        // y: adjustedY,
+        // x: anchorX,
+        // y: anchorY,
         // sortLayer: sprite.sortLayer, 
         sort: sprite.sort,
         linkedRegion:newLinkedRegion,

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -148,52 +148,6 @@ export function sortPlaceableByRegion(placeable) {
   }
 }
 
-// possible cases: 
-/** 
- * - region detection is not working properly
- * - sorting by position now is probably working properly now, at least it no longer get undefined or duplicates
- * - x/y sorting seems to still have issues with offset
- * - token sorting is broken again, currently very supicious of how the +1 - 1 case is often resolved as 0 , 
- *   like it seems that there is a case where all 4 conditions are ignored
- * 
- *  the sort by position is finally working as intended ( for now until a new bug is found) but seems to be quite more robust than before
- *  this is the next form of sorting that needs attention
-*/
-
-function compareSpriteByRegion(sprite,sibling) {
-  let sortChange = 0; // positive value = sorted above, negative value = sorted below
-  const currentSprite = sortableSprite(sprite);
-  const currentSibling = sortableSprite(sibling);
-
-    if(currentSprite.id !== currentSibling.id){
-    if (currentSprite.type === "Token" && currentSibling.type === "Tile"){
-      if(currentSprite.occupiedRegion && currentSibling.linkedRegion){
-        if( currentSprite.occupiedRegion === currentSibling.linkedRegion){
-          currentSprite.forceSortAbove = true
-          currentSibling.forceSortBelow = true
-        }
-      }
-
-    } else if (currentSprite.type === "Tile" && currentSibling.type === "Token"){
-      if(currentSprite.linkedRegion && currentSibling.occupiedRegion){
-        if(currentSprite.linkedRegion === currentSibling.occupiedRegion){
-          currentSprite.forceSortBelow = true
-          currentSibling.forceSortAbove = true
-        }
-      }
-    }
-
-    if(currentSprite.forceSortAbove){
-      sortChange = 1;
-    }
-    
-    if(currentSprite.forceSortBelow){
-      sortChange = -1;
-    }
-
- }
-}
-
 /**
  * compare two placeables by Y positions if one of the placable is a tile that is flipped
  * otherwise compare them by x positions.
@@ -212,6 +166,8 @@ function compareSpriteByPosition(sprite,sibling){
   const currentSibling = sortableSprite(sibling);
     if(currentSprite.tileMirrorHorizontal || currentSprite.tileFlipped || currentSibling.tileMirrorHorizontal || currentSibling.tileFlipped){
       sortChange = sortByY(currentSprite,currentSibling);
+    } else if(isRegionMatching(currentSprite,currentSibling)){ // still flickering
+      sortChange = -1;
     } else {
       sortChange = sortByX(currentSprite,currentSibling);
     }
@@ -221,6 +177,7 @@ function compareSpriteByPosition(sprite,sibling){
 function sortByX(spriteA , spriteB){
   let result = 1;
   if (spriteA.x > spriteB.x) { result = -1;}
+  // console.log("BY X?");
   return result;
 }
 
@@ -229,6 +186,18 @@ function sortByY(spriteA , spriteB){
   if (spriteA.y < spriteB.y) { result = -1;}
   return result;
 }
+
+// still not sure if that works
+function isRegionMatching (sprite, sibling){
+  if(sprite.occupiedRegion !== null && sibling.linkedRegion !== null){
+    if(sprite.occupiedRegion === sibling.linkedRegion){return true}
+  } else if(sibling.occupiedRegion !== null && sprite.linkedRegion !== null){
+    if(sibling.occupiedRegion === sprite.linkedRegion){return true}
+  } else {
+    return false;
+  }
+}
+
 
 // Generic function to create adjustable buttons with drag functionality
 export function createAdjustableButton(options) {
@@ -361,46 +330,69 @@ export function createAdjustableButton(options) {
 // }
 
 function sortableSprite(sprite){
-
+  // may seems overkill but passing the values directly sometimes cause weird "in between" value mutations that bricks sorting calculations
+  const id = sprite.object.document.id;
+  const type = sprite.object.document.documentName;
+  const name = sprite.object.document.name? sprite.object.document.name : "no name";
   let adjustedX = sprite.object.document.x;
   let adjustedY = sprite.object.document.y;
   if(sprite.object.document.documentName === "Tile"){
-    adjustedX = (sprite.object.document.x) - (sprite.object.document.width * 0.5)
-    adjustedY = (sprite.object.document.y) + (sprite.object.document.height * 0.25)
+    adjustedX = (sprite.object.document.x) - (sprite.object.document.width * 0.5);
+    adjustedY = (sprite.object.document.y) + (sprite.object.document.height * 0.25);
   }
+  const height = sprite.object.document.height;
+  const width = sprite.object.document.width;
+  let newLinkedRegion = sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID, 'regionLink');
+  let newOccupiedRegion = sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID, 'currentRegion');
+  if(!newLinkedRegion){newLinkedRegion = null};
+  if(!newOccupiedRegion){newOccupiedRegion = null};
+  const tileMirrorHorizontal = sprite.object.document.getFlag(fastFlipCompatiility.MODULE_ID, fastFlipCompatiility.TILE_MIRROR_HORIZONTAL)?sprite.object.document.getFlag(fastFlipCompatiility.MODULE_ID, fastFlipCompatiility.TILE_MIRROR_HORIZONTAL) : null;
+  const tileFlipped = sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID, 'tileFlipped')?sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID,'tileFlipped') : null;
+
   return {
-    id:sprite.object.document.id,
-    type:sprite.object.document.documentName,
-    name: sprite.object.document.name? sprite.object.document.name : "no name",
+    id:id,
+    type:type,
+    name: name,
     x: adjustedX,
     y: adjustedY,
-    height:sprite.object.document.height,
-    width:sprite.object.document.width,
+    height:height,
+    width:width,
     forceSortBelow: false,
     forceSortAbove: false,
-    linkedRegion:sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID, 'regionLink'),
-    occupiedRegion: sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID, 'currentRegion'),
-    tileMirrorHorizontal: sprite.object.document.getFlag(fastFlipCompatiility.MODULE_ID, fastFlipCompatiility.TILE_MIRROR_HORIZONTAL)?sprite.object.document.getFlag(fastFlipCompatiility.MODULE_ID, fastFlipCompatiility.TILE_MIRROR_HORIZONTAL) : null,
-    tileFlipped: sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID, 'tileFlipped')?sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID,'tileFlipped') : null
+    linkedRegion:newLinkedRegion,
+    occupiedRegion: newOccupiedRegion,
+    tileMirrorHorizontal: tileMirrorHorizontal,
+    tileFlipped: tileFlipped,
   }
-  return sortableSprite;
 }
 
-// for debugging canvasLayers
+// for debugging canvasLayers 
 export function debugCanvasLayer(spriteList){
     const data = []
+
     spriteList.map(sprite => {
+      let adjustedX = sprite.object.document.x;
+      let adjustedY = sprite.object.document.y;
+      if(sprite.object.document.documentName === "Tile"){
+        adjustedX = (sprite.object.document.x) - (sprite.object.document.width * 0.5)
+        adjustedY = (sprite.object.document.y) + (sprite.object.document.height * 0.25)
+      }
+
+      let newLinkedRegion = sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID, 'regionLink');
+      let newOccupiedRegion = sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID, 'currentRegion');
+      if(!newLinkedRegion){newLinkedRegion = null;}
+      if(!newOccupiedRegion){newOccupiedRegion = null;}
       data.push({
         // id: sprite.object.document.id,
         // type: sprite.object.document.documentName,
         name: sprite.object.document.name? sprite.object.document.name : "no name",
         //sprite.documentName === "Tile"? (sprite.x) - (sprite.width *0.25) : sprite.x,
-        // x: sprite.object.document.x,
-        // y: sprite.object.document.y,
-        x: sprite.object.document.documentName === "Tile"? (sprite.object.document.x) - (sprite.object.document.width*0.25) : sprite.object.document.x,
-        y: sprite.object.document.documentName === "Tile"? (sprite.object.document.y) + (sprite.object.document.width*0.25) : sprite.object.document.y,
+        // x: adjustedX,
+        // y: adjustedY,
         // sortLayer: sprite.sortLayer, 
         sort: sprite.sort,
+        linkedRegion:newLinkedRegion,
+        occupiedRegion: newOccupiedRegion,
         // occupiedRegion: sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID, 'currentRegion')? sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID, 'currentRegion') : "none",
         // tileMirrorHorizontal: sprite.object.document.getFlag(fastFlipCompatiility.MODULE_ID, fastFlipCompatiility.TILE_MIRROR_HORIZONTAL)?sprite.object.document.getFlag(fastFlipCompatiility.MODULE_ID, fastFlipCompatiility.TILE_MIRROR_HORIZONTAL) : null,
         // tileFlipped: sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID, 'tileFlipped')?sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID,'tileFlipped') : null,

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -172,16 +172,18 @@ function compareSpriteByPosition(sprite,sibling){
       sortChange = 1;
     }
   } else {
-    if(currentSprite.tileMirrorHorizontal || currentSprite.tileFlipped || currentSibling.tileMirrorHorizontal || currentSibling.tileFlipped){
-      if(currentSprite.type === "Tile"){drawTileAnchorLines(currentSprite)}
-      if(currentSibling.type === "Tile"){drawTileAnchorLines(currentSprite)}
-
-      sortChange = sortByY(currentSprite,currentSibling);
+    //token and tile interaction is quite tricky because it change based on if the tile is flipped or not ...
+    if( currentSprite.type === "Token" && currentSibling.tileMirrorHorizontal || currentSibling.tileFlipped){
+      sortChange = sortByY(currentSprite,currentSibling); // sort by Y axis if the tile is flipped
+    } else if( currentSibling.type === "Token" && currentSprite.tileMirrorHorizontal || currentSprite.tileFlipped){
+      sortChange = sortByY(currentSprite,currentSibling); // sort by Y axis if the tile is flipped
+    } else if( currentSprite.type === "Token" && !currentSibling.tileMirrorHorizontal || !currentSibling.tileFlipped ){
+      sortChange = sortByX(currentSprite,currentSibling); // sort by X axis if the tile is not flipped
+    } else if( currentSibling.type === "Token" && !currentSprite.tileMirrorHorizontal || !currentSprite.tileFlipped ){
+      sortChange = sortByX(currentSprite,currentSibling); // sort by X axis if the tile is not flipped
     } else {
-      if(currentSprite.type === "Tile"){drawTileAnchorLines(currentSprite)}
-      if(currentSibling.type === "Tile"){drawTileAnchorLines(currentSprite)}
-
-      sortChange = sortByX(currentSprite,currentSibling);
+      // cover the cases where its tile vs tile or token vs tokens
+      sortChange = sortByX(currentSprite,currentSibling); // sort by X axis if the tile is not flipped
     }
   }
   return sortChange;
@@ -190,13 +192,14 @@ function compareSpriteByPosition(sprite,sibling){
 function sortByX(spriteA , spriteB){
   let result = 1;
   if (spriteA.x > spriteB.x) { result = -1;}
-  // console.log("BY X?");
   return result;
 }
 
 function sortByY(spriteA , spriteB){
   let result = 1;
   if (spriteA.y < spriteB.y) { result = -1;}
+  else {result = 1;}
+  console.log("sprite", spriteA.name,spriteA.y, spriteB.name, spriteA.y,result)
   return result;
 }
 
@@ -330,7 +333,7 @@ export function createAdjustableButton(options) {
   });
 }
 
-function toggleAnchorAxis(object,toggle){
+export function toggleAnchorAxis(object,toggle){
   cleanupTileAnchorLines()
   if(toggle){
     drawTileAnchorLines(object)
@@ -402,12 +405,10 @@ function sortableSprite(sprite){
   const tileMirrorHorizontal = sprite.object.document.getFlag(fastFlipCompatiility.MODULE_ID, fastFlipCompatiility.TILE_MIRROR_HORIZONTAL)?sprite.object.document.getFlag(fastFlipCompatiility.MODULE_ID, fastFlipCompatiility.TILE_MIRROR_HORIZONTAL) : null;
   const tileFlipped = sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID, 'tileFlipped')?sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID,'tileFlipped') : null;
 
-  // console.log("sprite isoAnchorX", sprite.object.document)
-
-  if(sprite.object.document.documentName === "Tile"){
-    anchorX = (sprite.object.document.x) - (sprite.object.document.width * 0.5);
-    anchorY = (sprite.object.document.y) + (sprite.object.document.height * 0.5);
-  }
+  // if(sprite.object.document.documentName === "Tile"){
+  //   anchorX = (sprite.object.document.x) - (sprite.object.document.width * 0.5);
+  //   anchorY = (sprite.object.document.y) + (sprite.object.document.height * 0.5);
+  // }
 
   const height = sprite.object.document.height;
   const width = sprite.object.document.width;
@@ -443,10 +444,10 @@ export function debugCanvasLayer(spriteList){
     spriteList.map(sprite => {
       let anchorX = sprite.object.document.x;
       let anchorY = sprite.object.document.y;
-      if(sprite.object.document.documentName === "Tile"){
-        anchorX = (sprite.object.document.x) - (sprite.object.document.width * 0.5)
-        anchorY = (sprite.object.document.y) + (sprite.object.document.height * 0.25)
-      }
+      // if(sprite.object.document.documentName === "Tile"){
+      //   anchorX = (sprite.object.document.x) - (sprite.object.document.width * 0.25)
+      //   anchorY = (sprite.object.document.y) + (sprite.object.document.height * 0.25)
+      // }
 
       let newLinkedRegion = sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID, 'regionLink');
       let newOccupiedRegion = sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID, 'currentRegion');
@@ -457,14 +458,14 @@ export function debugCanvasLayer(spriteList){
         // type: sprite.object.document.documentName,
         name: sprite.object.document.name? sprite.object.document.name : "no name",
         //sprite.documentName === "Tile"? (sprite.x) - (sprite.width *0.25) : sprite.x,
-        // x: anchorX,
-        // y: anchorY,
+        x: anchorX,
+        y: anchorY,
         // sortLayer: sprite.sortLayer, 
         sort: sprite.sort,
-        linkedRegion:newLinkedRegion,
-        occupiedRegion: newOccupiedRegion,
+        // linkedRegion:newLinkedRegion,
+        // occupiedRegion: newOccupiedRegion,
         // occupiedRegion: sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID, 'currentRegion')? sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID, 'currentRegion') : "none",
-        // tileMirrorHorizontal: sprite.object.document.getFlag(fastFlipCompatiility.MODULE_ID, fastFlipCompatiility.TILE_MIRROR_HORIZONTAL)?sprite.object.document.getFlag(fastFlipCompatiility.MODULE_ID, fastFlipCompatiility.TILE_MIRROR_HORIZONTAL) : null,
+        tileMirrorHorizontal: sprite.object.document.getFlag(fastFlipCompatiility.MODULE_ID, fastFlipCompatiility.TILE_MIRROR_HORIZONTAL)?sprite.object.document.getFlag(fastFlipCompatiility.MODULE_ID, fastFlipCompatiility.TILE_MIRROR_HORIZONTAL) : null,
         // tileFlipped: sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID, 'tileFlipped')?sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID,'tileFlipped') : null,
       })
     });

--- a/templates/tile-config.hbs
+++ b/templates/tile-config.hbs
@@ -9,6 +9,13 @@
         <label for="{{rootId}}-isometric-perspective-enable-tile-isometrics-tile-sorting">{{localize 'isometric-perspective.tile_enableIsometric_sorting_name'}}</label>
         <input id="{{rootId}}-isometric-perspective-enable-tile-isometrics-tile-sorting" type="checkbox" name="flags.isometric-perspective.isoTileAutoSortingEnabled" {{checked document.flags.isometric-perspective.isoTileAutoSortingEnabled}}>
     </div>
+
+    <div class="form-group">
+        <label for="{{rootId}}-isometric-perspective-enable-offset-gizmo">{{localize 'isometric-perspective.tile_enableIsometric_anchor_gizmo'}}</label>
+        <input id="{{rootId}}-isometric-perspective-enable-offset-gizmo" type="checkbox" name="flags.isometric-perspective.isoOffsetGizmoEnabled" {{checked document.flags.isometric-perspective.isoOffsetGizmoEnabled}}>
+    </div>
+    <p class="hint">{{localize 'isometric-perspective.tile_enableIsometric_anchor_gizmo_hint'}}</p>
+
     <div class="form-group offset-point">
         <label>{{localize 'isometric-perspective.tile_artOffset_name'}}</label>
         <div class="form-fields">


### PR DESCRIPTION
whats done : 

- found another bug with the automatic depth sort and fixed it
- fixed the region based depth sort
- created a checkbox that show/hide tile alignment gizmo centered on the tile point of origin so users can align their walls better ( also help with autosorting ) 
- finished the draft for the portugese-br translation

whats left to do : 
- investigate the occasional bug with tile wall linking and potentially also region tile linking 
- a good QOL feature would be to add an isometric section in the tile palette and also display the art offset options in there so an user could batch edit similar sized tiles with the same offset in order for tiles to be centered on their point of origin , this would matter mostly for tiles with depth sort enabled but also a lot for hexagonal tiles 


