### PR TITLE
Warpspeednyancat v14 update

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -63,6 +63,8 @@
     "isometric-perspective.tile_enableIsometric_hint": "Disable isometric transformation on this tile.",
     "isometric-perspective.tile_enableIsometric_sorting_name": "Enable tile depth sorting",
     "isometric-perspective.tile_enableIsometric_sorting_hint": "Enable tile depth sorting on this tile.",
+    "isometric-perspective.tile_set_tile_facing": "Set tile facing",
+    "isometric-perspective.tile_set_tile_facing_hint": "Some tiles , for examples tiles representing a wall, may need additional data for the depth sorting feature to know how to properly sort them.",
     "isometric-perspective.tile_artOffset_name": "Art Offset",
     "isometric-perspective.tile_artOffset_hint": "Offset the tile art position in pixels.",
     "isometric-perspective.tile_enableIsometric_anchor_gizmo": "Enable art offset gizmo",

--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -63,6 +63,8 @@
     "isometric-perspective.tile_enableIsometric_hint": "Desabilita a transformação isométrica neste tile.",
     "isometric-perspective.tile_enableIsometric_sorting_name": "Ativar classificação por profundidade de mosaico",
     "isometric-perspective.tile_enableIsometric_sorting_hint": "Ative a classificação por profundidade de mosaico neste mosaico.",
+    "isometric-perspective.tile_set_tile_facing": "Definir revestimento de Tile",
+    "isometric-perspective.tile_set_tile_facing_hint": "Algumas Tiles, por exemplo, peças que representam uma parede, podem precisar de dados adicionais para que o recurso de classificação por profundidade saiba como classificá-las corretamente.",
     "isometric-perspective.tile_artOffset_name": "Deslocamento da Arte",
     "isometric-perspective.tile_artOffset_hint": "Desloca a posição da arte do tile no número de pixels indicado.",
     "isometric-perspective.tile_enableIsometric_anchor_gizmo": "Ativar gizmo de deslocamento de arte",

--- a/scripts/autosorting.js
+++ b/scripts/autosorting.js
@@ -79,7 +79,7 @@ export function isoDepthSortTokenMixin(Base){
         currentSprite.object.document.sort = i;
         currentSprite.sort = i;
       }
-      // debugCanvasLayer(this.sortList) -------------------------------------------------------------------------- DEBUG!!!
+      // debugCanvasLayer(this.sortList) //-------------------------------------------------------------------------- DEBUG!!!
       this.mesh.parent.sortDirty = true;
     }
 

--- a/scripts/autosorting.js
+++ b/scripts/autosorting.js
@@ -43,21 +43,21 @@ export function isoDepthSortTileMixin(Base){
         }
       }
       
-      if(this.controlled){
-        toggleAnchorAxis(this.document, true); 
-        //show extra controls
-        // modify the toggle function to show an orientation control UI , like two diagonal arrow buttons to set the tile orientation
-        // and one double arrow representing a flip function
-        // change the lines of the gizmo so only the orientation axis is displayed
+      // if(this.controlled){
+      //   toggleAnchorAxis(this.document, true); 
+      //   //show extra controls
+      //   // modify the toggle function to show an orientation control UI , like two diagonal arrow buttons to set the tile orientation
+      //   // and one double arrow representing a flip function
+      //   // change the lines of the gizmo so only the orientation axis is displayed
 
-        // icons to use : https://fontawesome.com/icons/categories/classic/solid/arrows
-        // look into foundry's hud feature
-        // also only the gm should be able to see it
-      }
+      //   // icons to use : https://fontawesome.com/icons/categories/classic/solid/arrows
+      //   // look into foundry's hud feature
+      //   // also only the gm should be able to see it
+      // }
 
-      if(!this.controlled){
-        toggleAnchorAxis(this.document, false);
-      }
+      // if(!this.controlled){
+      //   toggleAnchorAxis(this.document, false);
+      // }
     }
   }
 }

--- a/scripts/autosorting.js
+++ b/scripts/autosorting.js
@@ -2,7 +2,8 @@ import { isometricModuleConfig } from './consts.js';
 import { 
   sortPlaceableByPosition,
   sortPlaceableByRegion,
-  debugCanvasLayer
+  debugCanvasLayer,
+  toggleAnchorAxis
 } from './utils.js';
 
 export function isoDepthSortTileMixin(Base){
@@ -30,18 +31,29 @@ export function isoDepthSortTileMixin(Base){
       }
       const isTileSortable = this.document.getFlag(isometricModuleConfig.MODULE_ID, 'isoTileAutoSortingEnabled');
       if(isTileSortable){
-      if ("y" in changed || "x" in changed) {
-        const sortList = sortPlaceableByPosition(this);
-        for (let i = 0; i < sortList.length; i++) {
-          const currentSprite = sortList[i];
-          currentSprite.object.document.sort = i;
-          currentSprite.sort = i;
-        }
-
+        if ("y" in changed || "x" in changed) {
+          const sortList = sortPlaceableByPosition(this);
+          for (let i = 0; i < sortList.length; i++) {
+            const currentSprite = sortList[i];
+            currentSprite.object.document.sort = i;
+            currentSprite.sort = i;
+          }
+          // debugCanvasLayer(sortList) //-------------------------------------------------------------------------- DEBUG!!!
           this.mesh.parent.sortDirty = true;
         }
       }
       
+      if(this.controlled){
+        //show extra controls
+        toggleAnchorAxis(this.document, true); 
+        // modify the toggle function to show an orientation control UI , like two diagonal arrow buttons to set the tile orientation
+        // and one double arrow representing a flip function
+        // change the lines of the gizmo so only the orientation axis is displayed
+
+        // icons to use : https://fontawesome.com/icons/categories/classic/solid/arrows
+        // look into foundry's hud feature
+        // also only the gm should be able to see it
+      }
 
     }
   }

--- a/scripts/autosorting.js
+++ b/scripts/autosorting.js
@@ -59,8 +59,10 @@ export function isoDepthSortTokenMixin(Base){
     _refreshState() {
       super._refreshState();
       //prevent mesh flickering on hover or controlled
-      this.zIndex = 0;
-      this.mesh.zIndex = 0;
+      if(this.zIndex){
+        this.zIndex = 0;
+        this.mesh.zIndex = 0;
+      }
 
         const currentRegions = Array.from(this.document.regions).map(region => region);
         const currentRegion = currentRegions[0]?._id;
@@ -77,14 +79,16 @@ export function isoDepthSortTokenMixin(Base){
         currentSprite.object.document.sort = i;
         currentSprite.sort = i;
       }
-      // debugCanvasLayer(this.sortList)
+      // debugCanvasLayer(this.sortList) -------------------------------------------------------------------------- DEBUG!!!
       this.mesh.parent.sortDirty = true;
     }
 
     _onUpdate(changed, options, userId) {
       super._onUpdate(changed, options, userId);
-      this.zIndex = 0;
-      this.mesh.zIndex = 0;
+      if(this.zIndex){
+        // this.zIndex = 0;
+        // this.mesh.zIndex = 0;
+      }
       if ("y" in changed || "x" in changed) {
         // later use this to prevent unecessary updates
       }

--- a/scripts/autosorting.js
+++ b/scripts/autosorting.js
@@ -44,8 +44,8 @@ export function isoDepthSortTileMixin(Base){
       }
       
       if(this.controlled){
-        //show extra controls
         toggleAnchorAxis(this.document, true); 
+        //show extra controls
         // modify the toggle function to show an orientation control UI , like two diagonal arrow buttons to set the tile orientation
         // and one double arrow representing a flip function
         // change the lines of the gizmo so only the orientation axis is displayed
@@ -55,6 +55,9 @@ export function isoDepthSortTileMixin(Base){
         // also only the gm should be able to see it
       }
 
+      if(!this.controlled){
+        toggleAnchorAxis(this.document, false);
+      }
     }
   }
 }

--- a/scripts/consts.js
+++ b/scripts/consts.js
@@ -165,11 +165,25 @@ export const fastFlipCompatiility = {
 }
 
 export const TILE_FACINGS = [
-  'south west to north east',
-  'south east to north west'
+  {
+    facing:'south west to north east',
+    sortingRule: "X" //  -> / x axis direction
+  },
+  {
+    facing:'south east to north west',
+    sortingRule: "Y" //  -> \ y axis direction
+  },
+  {
+    facing:'horizontal',
+    sortingRule: "Depth" //
+  },
+  {
+    facing:'vertical',
+    sortingRule: "Depth" //  
+  },
 ]
 
-export const DEFAULT_TILE_FACING = 'south east to north west'
+export const DEFAULT_TILE_FACING = 'south west to north east'
 
 /*
 // values in degrees

--- a/scripts/consts.js
+++ b/scripts/consts.js
@@ -166,24 +166,24 @@ export const fastFlipCompatiility = {
 
 export const TILE_FACINGS = [
   {
-    facing:'south west to north east',
+    facing:'south west',
     sortingRule: "X" //  -> / x axis direction
   },
   {
-    facing:'south east to north west',
+    facing:'south east',
     sortingRule: "Y" //  -> \ y axis direction
   },
   {
-    facing:'horizontal',
+    facing:'south',
     sortingRule: "Depth" //
   },
   {
-    facing:'vertical',
+    facing:'side',
     sortingRule: "Depth" //  
   },
 ]
 
-export const DEFAULT_TILE_FACING = 'south west to north east'
+export const DEFAULT_TILE_FACING = 'south west'
 
 /*
 // values in degrees

--- a/scripts/consts.js
+++ b/scripts/consts.js
@@ -164,6 +164,13 @@ export const fastFlipCompatiility = {
   TILE_MIRROR_HORIZONTAL: "tileMirrorHorizontal"
 }
 
+export const TILE_FACINGS = [
+  'south west to north east',
+  'south east to north west'
+]
+
+export const DEFAULT_TILE_FACING = 'south east to north west'
+
 /*
 // values in degrees
 export let ISOMETRIC_CONST = {

--- a/scripts/hud.js
+++ b/scripts/hud.js
@@ -25,9 +25,6 @@ export function handleRenderTileHUD(hud, html, data) {
   }
 }
 
-
-
-
 export function handleRenderDrawingHUD(hud, html, data) {
   const scene = game.scenes.current;
   const isSceneIsometric = scene.getFlag(isometricModuleConfig.MODULE_ID, "isometricEnabled");

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -16,7 +16,8 @@ import {
   handleCreateTile,
   handleUpdateTile,
   handleRefreshTile,
-  addDepthSortControls
+  addDepthSortControls,
+  closeConfig
  } from './tile.js';
 
  import {
@@ -270,6 +271,7 @@ Hooks.on("ready", createTileIsometricTab);
 Hooks.on("renderTileConfig", initTileForm);
 Hooks.on("createTile", handleCreateTile);
 Hooks.on("updateTile", handleUpdateTile);
+Hooks.on("closeTileConfig", closeConfig);
 Hooks.on("refreshTile", handleRefreshTile);
 Hooks.on("getSceneControlButtons", controls => {
   addDepthSortControls(controls);

--- a/scripts/regions.js
+++ b/scripts/regions.js
@@ -24,18 +24,24 @@ export function initRegionForm(app, html, context, options){
   const linkTilesBox = html.querySelector('.linked-tiles-container');
   const isRegionDepthSortEnabled = app.document.getFlag(isometricModuleConfig.MODULE_ID, 'isoRegionTilesAutoSortingEnabled');
   
-  depthSortingCheckbox.addEventListener('change', (event) => {
-    if (event.target.checked === true){
-      app.document.setFlag(isometricModuleConfig.MODULE_ID, 'isoRegionTilesAutoSortingEnabled', true);
-    } else {
-      app.document.setFlag(isometricModuleConfig.MODULE_ID, 'isoRegionTilesAutoSortingEnabled', false);
-    }
-  });
+  // since the introduction of placeable palettes tools , adding references to UI elements like this cause an error if there is no checker to see if the 
+  // ui element reference exist.
+  if(depthSortingCheckbox){
+    depthSortingCheckbox.addEventListener('change', (event) => {
+      if (event.target.checked === true){
+        app.document.setFlag(isometricModuleConfig.MODULE_ID, 'isoRegionTilesAutoSortingEnabled', true);
+      } else {
+        app.document.setFlag(isometricModuleConfig.MODULE_ID, 'isoRegionTilesAutoSortingEnabled', false);
+      }
+    });
+  }
 
-  if (isRegionDepthSortEnabled){
-    linkTilesBox.classList.remove('hidden');
-  } else {
-    linkTilesBox.classList.add('hidden');
+  if(linkTilesBox){
+    if (isRegionDepthSortEnabled){
+      linkTilesBox.classList.remove('hidden');
+    } else {
+      linkTilesBox.classList.add('hidden');
+    }
   }
 
 // Region room tiles linking

--- a/scripts/tile.js
+++ b/scripts/tile.js
@@ -24,7 +24,7 @@ export async function createTileIsometricTab(app, html, data) {
   const DefaultTileConfig = Object.values(CONFIG.Tile.sheetClasses.base).find((d) => d.default)?.cls;
   const TileConfig = DefaultTileConfig?.prototype instanceof FoundryTileConfig ? DefaultTileConfig : FoundryTileConfig;
 
-  const tileFacings =  [...TILE_FACINGS];
+  const tileFacings =  TILE_FACINGS.map( obj => obj.facing);
   const currentTileFacing = TileConfig.object?.getFlag(isometricModuleConfig.MODULE_ID, 'tileFacing') ?? DEFAULT_TILE_FACING;
 
   const wallFacingConfig = {
@@ -113,6 +113,8 @@ export function initTileForm(app, html, context, options){
     await app.document.setFlag(isometricModuleConfig.MODULE_ID, 'linkedWallIds', []);
     if (linkedWallsIdInput) linkedWallsIdInput.value = '';
   }
+
+  console.log("app.document",app.document)
 }
 
 export function closeConfig(app){

--- a/scripts/tile.js
+++ b/scripts/tile.js
@@ -61,16 +61,20 @@ export function initTileForm(app, html, context, options){
   const currentScale = app.document.getFlag(isometricModuleConfig.MODULE_ID, 'scale');
 
   // Art offset
-  gizmoEnabledCheckbox.addEventListener('change', (event) => {
-    const tileDocument = context.document;
-    if(event.target.checked){
-      tileDocument.setFlag(isometricModuleConfig.MODULE_ID,"isoOffsetGizmoEnabled", true);
-      toggleAnchorAxis(tileDocument,true);
-    } else {
-      tileDocument.setFlag(isometricModuleConfig.MODULE_ID,"isoOffsetGizmoEnabled", false);
-      toggleAnchorAxis(tileDocument,false);
-    }
-  }) 
+  // since the introduction of placeable palettes tools , adding references to UI elements like this cause an error if there is no checker to see if the 
+  // ui element reference exist.
+  if(gizmoEnabledCheckbox){ 
+    gizmoEnabledCheckbox.addEventListener('change', (event) => {
+      const tileDocument = context.document;
+      if(event.target.checked){
+        tileDocument.setFlag(isometricModuleConfig.MODULE_ID,"isoOffsetGizmoEnabled", true);
+        toggleAnchorAxis(tileDocument,true);
+      } else {
+        tileDocument.setFlag(isometricModuleConfig.MODULE_ID,"isoOffsetGizmoEnabled", false);
+        toggleAnchorAxis(tileDocument,false);
+      }
+    }) 
+  }
 
   const inputOffsetX = html.querySelector('input[name="flags.isometric-perspective.offsetX"]');
   const inputOffsetY = html.querySelector('input[name="flags.isometric-perspective.offsetY"]');
@@ -113,8 +117,6 @@ export function initTileForm(app, html, context, options){
     await app.document.setFlag(isometricModuleConfig.MODULE_ID, 'linkedWallIds', []);
     if (linkedWallsIdInput) linkedWallsIdInput.value = '';
   }
-
-  console.log("app.document",app.document)
 }
 
 export function closeConfig(app){

--- a/scripts/tile.js
+++ b/scripts/tile.js
@@ -1,4 +1,4 @@
-import { isometricModuleConfig } from './consts.js';
+import { isometricModuleConfig, TILE_FACINGS, DEFAULT_TILE_FACING } from './consts.js';
 import { applyIsometricTransformation } from './transform.js';
 import { 
   adjustInputWithMouseDrag, 
@@ -23,7 +23,16 @@ export async function createTileIsometricTab(app, html, data) {
   const FoundryTileConfig = foundry.applications.sheets.TileConfig;
   const DefaultTileConfig = Object.values(CONFIG.Tile.sheetClasses.base).find((d) => d.default)?.cls;
   const TileConfig = DefaultTileConfig?.prototype instanceof FoundryTileConfig ? DefaultTileConfig : FoundryTileConfig;
-  patchConfig(TileConfig,tileTabConfig);
+
+  const tileFacings =  [...TILE_FACINGS];
+  const currentTileFacing = TileConfig.object?.getFlag(isometricModuleConfig.MODULE_ID, 'tileFacing') ?? DEFAULT_TILE_FACING;
+
+  const wallFacingConfig = {
+    tileFacing: tileFacings,
+    document: currentTileFacing
+  }
+
+  patchConfig(TileConfig,tileTabConfig,wallFacingConfig);
   
 }
 
@@ -51,13 +60,11 @@ export function initTileForm(app, html, context, options){
   const currentOffsetY = app.document.getFlag(isometricModuleConfig.MODULE_ID, 'offsetY');
   const currentScale = app.document.getFlag(isometricModuleConfig.MODULE_ID, 'scale');
 
-
   // Art offset
   gizmoEnabledCheckbox.addEventListener('change', (event) => {
     const tileDocument = context.document;
     if(event.target.checked){
       tileDocument.setFlag(isometricModuleConfig.MODULE_ID,"isoOffsetGizmoEnabled", true);
-      console.log("tileDocument", tileDocument)
       toggleAnchorAxis(tileDocument,true);
     } else {
       tileDocument.setFlag(isometricModuleConfig.MODULE_ID,"isoOffsetGizmoEnabled", false);
@@ -105,6 +112,14 @@ export function initTileForm(app, html, context, options){
   async function clearWall () {
     await app.document.setFlag(isometricModuleConfig.MODULE_ID, 'linkedWallIds', []);
     if (linkedWallsIdInput) linkedWallsIdInput.value = '';
+  }
+}
+
+export function closeConfig(app){
+  const tileDocument = app.options.document
+  if (tileDocument.getFlag(isometricModuleConfig.MODULE_ID,"isoOffsetGizmoEnabled") === true){
+    tileDocument.setFlag(isometricModuleConfig.MODULE_ID,"isoOffsetGizmoEnabled", false);
+    toggleAnchorAxis(tileDocument,false);
   }
 }
 

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -162,25 +162,26 @@ function compareSpriteByPosition(sprite,sibling){
   const currentSprite = sortableSprite(sprite);
   const currentSibling = sortableSprite(sibling);
 
+  // if(currentSprite.type === "Tile" && currentSibling.type === "Tile"){
+  //   console.log("VERTICAL SORT:");
+  // }
+
+  // for cases with tiles linked to a region with region sort enabled.
   if(isRegionMatching(currentSprite,currentSibling)){
-    if(currentSprite.type === "Tile"){
-      sortChange = -1;
-    } else if (currentSibling.type === "Tile"){
-      sortChange = 1;
-    }
+    sortChange = sortByRegion(currentSprite,currentSibling);
   } else {
     //token and tile interaction is quite tricky because it change based on if the tile is flipped or not ...
-    if( currentSprite.type === "Token" && currentSibling.tileMirrorHorizontal || currentSibling.tileFlipped){
+    if( currentSprite.type === "Token" && currentSibling.tileMirrorHorizontal  === true  || currentSprite.type === "Token" && currentSibling.tileFlipped  === true ){
       sortChange = sortByY(currentSprite,currentSibling); // sort by Y axis if the tile is flipped
-    } else if( currentSibling.type === "Token" && currentSprite.tileMirrorHorizontal || currentSprite.tileFlipped){
+    } else if( currentSibling.type === "Token" && currentSprite.tileMirrorHorizontal  === true  || currentSibling.type === "Token" && currentSprite.tileFlipped  === true ){
       sortChange = sortByY(currentSprite,currentSibling); // sort by Y axis if the tile is flipped
-    } else if( currentSprite.type === "Token" && !currentSibling.tileMirrorHorizontal || !currentSibling.tileFlipped ){
+    } else if( currentSprite.type === "Token" && !currentSibling.tileMirrorHorizontal || currentSprite.type === "Token" && !currentSibling.tileFlipped ){
       sortChange = sortByX(currentSprite,currentSibling); // sort by X axis if the tile is not flipped
-    } else if( currentSibling.type === "Token" && !currentSprite.tileMirrorHorizontal || !currentSprite.tileFlipped ){
+    } else if( currentSibling.type === "Token" && !currentSprite.tileMirrorHorizontal || currentSibling.type === "Token" && !currentSprite.tileFlipped ){
       sortChange = sortByX(currentSprite,currentSibling); // sort by X axis if the tile is not flipped
     } else {
-      // cover the cases where its tile vs tile or token vs tokens
-      sortChange = sortByX(currentSprite,currentSibling); // sort by X axis if the tile is not flipped
+      // cover the cases where its tile vs tile or token vs tokens, in that case simply sort by vertical difference between both center points
+      sortChange = sortByVertical(currentSprite,currentSibling);
     }
   }
   return sortChange;
@@ -191,37 +192,40 @@ function compareSpriteByPosition(sprite,sibling){
 
 function sortByX(spriteA , spriteB){
   let result = 1;
-  // if ( spriteA.name === "orc fighter" || spriteB.name === "orc fighter") {
-  //   console.log("orc fighter sorted by X")
-  // }
   if (spriteA.x >= spriteB.x) { result = -1;}
   return result;
 }
 
 function sortByY(spriteA , spriteB){
   let result = 1;
-  // if ( spriteA.name === "orc fighter" || spriteB.name === "orc fighter") {
-  //   console.log("orc fighter sorted by Y")
-  // }
   if (spriteA.y <= spriteB.y) { result = -1;}
   else {result = 1;}
-  // console.log("sprite", spriteA.name,spriteA.y, spriteB.name, spriteA.y,result)
+  return result;
+}
+
+function sortByRegion(spriteA , spriteB){
+  if(spriteA.type === "Tile"){
+    return -1;
+  } else if (spriteB.type === "Tile"){
+    return 1;
+  }
+}
+
+function sortByVertical(spriteA , spriteB) {
+  let result = 1;
+    if(spriteA.x > spriteB.x && spriteA.y < spriteB.y){
+      result = -1;
+    }
   return result;
 }
 
 function isRegionMatching (sprite, sibling){
   if(sprite.occupiedRegion !== null && sibling.linkedRegion !== null){
     if(sprite.occupiedRegion === sibling.linkedRegion){
-      // if ( sprite.name === "orc fighter" || sibling.name === "orc fighter") {
-      //   console.log("orc fighter sorted by REGION")
-      // }
       return true
     }
   } else if(sibling.occupiedRegion !== null && sprite.linkedRegion !== null){
     if(sibling.occupiedRegion === sprite.linkedRegion){
-      // if ( sprite.name === "orc fighter" || sibling.name === "orc fighter") {
-      //   console.log("orc fighter sorted by REGION")
-      // }
       return true
     }
   } else {
@@ -470,15 +474,15 @@ export function debugCanvasLayer(spriteList){
         // type: sprite.object.document.documentName,
         // name: sprite.object.document.name? sprite.object.document.name : "no name",
         //sprite.documentName === "Tile"? (sprite.x) - (sprite.width *0.25) : sprite.x,
-        // x: anchorX,
-        // y: anchorY,
+        x: anchorX,
+        y: anchorY,
         // sortLayer: sprite.sortLayer, 
         // sort: sprite.sort,
         // linkedRegion:newLinkedRegion,
         // occupiedRegion: newOccupiedRegion,
         // occupiedRegion: sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID, 'currentRegion')? sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID, 'currentRegion') : "none",
-        // tileMirrorHorizontal: sprite.object.document.getFlag(fastFlipCompatiility.MODULE_ID, fastFlipCompatiility.TILE_MIRROR_HORIZONTAL)?sprite.object.document.getFlag(fastFlipCompatiility.MODULE_ID, fastFlipCompatiility.TILE_MIRROR_HORIZONTAL) : null,
-        // tileFlipped: sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID, 'tileFlipped')?sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID,'tileFlipped') : null,
+        tileMirrorHorizontal: sprite.object.document.getFlag(fastFlipCompatiility.MODULE_ID, fastFlipCompatiility.TILE_MIRROR_HORIZONTAL)?sprite.object.document.getFlag(fastFlipCompatiility.MODULE_ID, fastFlipCompatiility.TILE_MIRROR_HORIZONTAL) : null,
+        tileFlipped: sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID, 'tileFlipped')?sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID,'tileFlipped') : null,
       })
     });
     console.table(data)

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -162,48 +162,71 @@ function compareSpriteByPosition(sprite,sibling){
   const currentSprite = sortableSprite(sprite);
   const currentSibling = sortableSprite(sibling);
 
-  // if(currentSprite.type === "Tile" && currentSibling.type === "Tile"){
-  //   console.log("VERTICAL SORT:");
-  // }
-
   // for cases with tiles linked to a region with region sort enabled.
   if(isRegionMatching(currentSprite,currentSibling)){
     sortChange = sortByRegion(currentSprite,currentSibling);
-  } else {
-    //token and tile interaction is quite tricky because it change based on if the tile is flipped or not ...
-    if( currentSprite.type === "Token" && currentSibling.tileMirrorHorizontal  === true  || currentSprite.type === "Token" && currentSibling.tileFlipped  === true ){
+  } else if (isTokenAndTile(currentSprite , currentSibling) ) {
+    if(isTileFlipped(currentSprite) || isTileFlipped(currentSibling)){
       sortChange = sortByY(currentSprite,currentSibling); // sort by Y axis if the tile is flipped
-    } else if( currentSibling.type === "Token" && currentSprite.tileMirrorHorizontal  === true  || currentSibling.type === "Token" && currentSprite.tileFlipped  === true ){
-      sortChange = sortByY(currentSprite,currentSibling); // sort by Y axis if the tile is flipped
-    } else if( currentSprite.type === "Token" && !currentSibling.tileMirrorHorizontal || currentSprite.type === "Token" && !currentSibling.tileFlipped ){
-      sortChange = sortByX(currentSprite,currentSibling); // sort by X axis if the tile is not flipped
-    } else if( currentSibling.type === "Token" && !currentSprite.tileMirrorHorizontal || currentSibling.type === "Token" && !currentSprite.tileFlipped ){
-      sortChange = sortByX(currentSprite,currentSibling); // sort by X axis if the tile is not flipped
     } else {
-      // cover the cases where its tile vs tile or token vs tokens, in that case simply sort by vertical difference between both center points
-      sortChange = sortByVertical(currentSprite,currentSibling);
+      sortChange = sortByX(currentSprite,currentSibling); // sort by X axis if the tile is not flipped
     }
+  } else {
+    sortChange = sortByVertical(currentSprite,currentSibling);
   }
   return sortChange;
+}
+
+// bit overkill but make code much more readable and avoid duplicate compar logic
+function isTokenAndTile(spriteA, spriteB){
+  let result = false;
+  if(spriteA.type ==="Token" && spriteB.type ==="Tile" || spriteA.type ==="Tile" && spriteB.type ==="Token"){
+    result = true;
+  }
+  return result;
+}
+
+function isBothTile(spriteA, spriteB){
+  let result = false;
+  if(spriteA.type ==="Tile" && spriteB.type ==="Tile"){
+    result = true;
+  }
+  return result;
+}
+
+function isTileFlipped(sprite){
+  let result = false;
+  if(sprite.tileMirrorHorizontal || sprite.tileFlipped){
+    result = true;
+  }
+  return result;
 }
 
 // ties in y still cause values cause flicker
 // multiples tokens canc ause the logic to break sometimes for some reason
 
-function sortByX(spriteA , spriteB){
+function sortByX(spriteA, spriteB){
   let result = 1;
   if (spriteA.x >= spriteB.x) { result = -1;}
   return result;
 }
 
-function sortByY(spriteA , spriteB){
+function sortByY(spriteA, spriteB){
+  if (spriteA.name === "glitched wall back" && spriteB.name === "glitched wall back"){
+    console.log("SORTED Y?")
+    console.log("A IS :", spriteA.name)
+    console.log("B IS:", spriteB.name)
+    console.log("IS TOKEN AND TILE?", isTokenAndTile(spriteA, spriteB))
+    console.log("IS BOTH TILES?", isBothTile(spriteA, spriteB))
+    console.log("IS A FLIPPED?", isTileFlipped(spriteA))
+    console.log("IS B FLIPPED?", isTileFlipped(spriteB))
+  }
   let result = 1;
   if (spriteA.y <= spriteB.y) { result = -1;}
-  else {result = 1;}
   return result;
 }
 
-function sortByRegion(spriteA , spriteB){
+function sortByRegion(spriteA, spriteB){
   if(spriteA.type === "Tile"){
     return -1;
   } else if (spriteB.type === "Tile"){
@@ -211,7 +234,16 @@ function sortByRegion(spriteA , spriteB){
   }
 }
 
-function sortByVertical(spriteA , spriteB) {
+function sortByVertical(spriteA, spriteB) {
+  if (spriteA.name === "glitched wall back" && spriteB.name === "glitched wall front"){
+    console.log("SORTED VERTICAL?")
+    console.log("A IS :", spriteA.name, "coords:", spriteA.x, spriteA.y)
+    console.log("B IS:", spriteB.name, "coords:", spriteB.x, spriteB.y)
+    console.log("IS TOKEN AND TILE?", isTokenAndTile(spriteA, spriteB))
+    console.log("IS BOTH TILES?", isBothTile(spriteA, spriteB))
+    console.log("IS A FLIPPED?", isTileFlipped(spriteA))
+    console.log("IS B FLIPPED?", isTileFlipped(spriteB))
+  }
   let result = 1;
     if(spriteA.x > spriteB.x && spriteA.y < spriteB.y){
       result = -1;
@@ -221,16 +253,10 @@ function sortByVertical(spriteA , spriteB) {
 
 function isRegionMatching (sprite, sibling){
   if(sprite.occupiedRegion !== null && sibling.linkedRegion !== null){
-    if(sprite.occupiedRegion === sibling.linkedRegion){
-      return true
-    }
+    if(sprite.occupiedRegion === sibling.linkedRegion){ return true }
   } else if(sibling.occupiedRegion !== null && sprite.linkedRegion !== null){
-    if(sibling.occupiedRegion === sprite.linkedRegion){
-      return true
-    }
-  } else {
-    return false;
-  }
+    if(sibling.occupiedRegion === sprite.linkedRegion){ return true }
+  } else { return false; }
 }
 
 
@@ -472,7 +498,7 @@ export function debugCanvasLayer(spriteList){
       data.push({
         // id: sprite.object.document.id,
         // type: sprite.object.document.documentName,
-        // name: sprite.object.document.name? sprite.object.document.name : "no name",
+        name: sprite.object.document.name? sprite.object.document.name : "no name",
         //sprite.documentName === "Tile"? (sprite.x) - (sprite.width *0.25) : sprite.x,
         x: anchorX,
         y: anchorY,

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -113,23 +113,6 @@ export function patchConfig(documentSheet, config, args) {
   }
 }
 
-/**
- * change placeables sort values based on its y value on the grid compared to its siblings.
- * @param {Placeable|PlaceableDocument} placeable - The placeable document used as a reference for the sortlayer.
- */
-export function sortPlaceableByPosition(placeable) {
-  if(placeable.mesh.sortLayer === foundry.canvas.groups.PrimaryCanvasGroup.SORT_LAYERS.TOKENS ){
-    const placeableMeshLayer = foundry.canvas.groups.PrimaryCanvasGroup.SORT_LAYERS.TOKENS;
-    const canvasLayer = canvas.primary.children;
-    const currentSortLayer = placeable.mesh.parent
-    return canvasLayer
-    .filter( sprite => sprite.sortLayer === placeableMeshLayer)
-    .toSorted((sprite,sibling)=> compareSpriteByPosition(sprite,sibling));
-
-    // starting to think the sorting algorithm cause side effects 
-  }
-}
-
 export function sortPlaceableByRegion(placeable) {
   if(placeable.mesh.sortLayer === foundry.canvas.groups.PrimaryCanvasGroup.SORT_LAYERS.TOKENS ){
     const placeableMeshLayer = foundry.canvas.groups.PrimaryCanvasGroup.SORT_LAYERS.TOKENS;
@@ -141,9 +124,9 @@ export function sortPlaceableByRegion(placeable) {
       let compare = 0;
       if( sprite.object.document.documentName === "Token" || sibling.object.document.documentName === "Token" ) {
         if(sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID, 'currentRegion')){
-          compare = compareSpriteByRegion(sprite,sibling);
+          compare = comparesiblingyRegion(sprite,sibling);
         } else if (sibling.object.document.getFlag(isometricModuleConfig.MODULE_ID, 'currentRegion')) {
-          compare = compareSpriteByRegion(sprite,sibling);
+          compare = comparesiblingyRegion(sprite,sibling);
         }
         return compare;
       }
@@ -151,6 +134,26 @@ export function sortPlaceableByRegion(placeable) {
 
   }
 }
+
+/**
+ * change placeables sort values based on its y value on the grid compared to its siblings.
+ * @param {Placeable|PlaceableDocument} placeable - The placeable document used as a reference for the sortlayer.
+ * 
+ * 
+ */
+export function sortPlaceableByPosition(placeable) {
+  if(placeable.mesh.sortLayer === foundry.canvas.groups.PrimaryCanvasGroup.SORT_LAYERS.TOKENS ){
+    const placeableMeshLayer = foundry.canvas.groups.PrimaryCanvasGroup.SORT_LAYERS.TOKENS;
+    const canvasLayer = canvas.primary.children;
+    const currentSortLayer = placeable.mesh.parent
+    return canvasLayer.filter( sprite => sprite.sortLayer === placeableMeshLayer)
+    .sort((sprite,sibling)=> compareSiblingPosition(sprite,sibling))
+    .toSorted((sprite,sibling)=> compareSiblingPosition(sprite,sibling));
+
+    // starting to think the sorting algorithm cause side effects 
+  }
+}
+
 
 /**
  * compare two placeables by Y positions if one of the placable is a tile that is flipped
@@ -164,11 +167,10 @@ export function sortPlaceableByRegion(placeable) {
  * x-        y+
 */
 
-function compareSpriteByPosition(sprite,sibling){    
+function compareSiblingPosition(sprite,sibling){    
   let sortChange = 0;
   const currentSprite = sortableSprite(sprite);
   const currentSibling = sortableSprite(sibling);
-
   // for cases with tiles linked to a region with region sort enabled.
   if(isRegionMatching(currentSprite,currentSibling)){
     sortChange = sortByRegion(currentSprite,currentSibling);
@@ -178,24 +180,7 @@ function compareSpriteByPosition(sprite,sibling){
   return sortChange;
 }
 
-// bit overkill but make code much more readable and avoid duplicate compar logic
-// function isTokenAndTile(spriteA, spriteB){
-//   let result = false;
-//   if(spriteA.type ==="Token" && spriteB.type ==="Tile" || spriteA.type ==="Tile" && spriteB.type ==="Token"){
-//     result = true;
-//   }
-//   return result;
-// }
-
-// function isBothTile(spriteA, spriteB){
-//   let result = false;
-//   if(spriteA.type ==="Tile" && spriteB.type ==="Tile"){
-//     result = true;
-//   }
-//   return result;
-// }
-
-function isTileFlipped(sprite){
+function isTileFlipped (sprite){
   let result = false;
   if(sprite.tileMirrorHorizontal || sprite.tileFlipped){
     result = true;
@@ -203,92 +188,85 @@ function isTileFlipped(sprite){
   return result;
 }
 
+// return true or false based on if a tile sortRule is by X or by Y axis and invert the result if the tile is also flipped 
+// other result always return false because no axis check is needed and such tiles are always sorted by vertical depth.
+function isTileAxisFlipped(sprite){
+  if(sprite.sortRule === "X"){
+    return isTileFlipped(sprite)? true : false;
+  } else if (sprite.sortRule === "Y"){
+    return isTileFlipped(sprite)? true : false;
+  } else {
+    return false;
+  }
+}
+
+// compare cases where the placeable type is: 
+// token vs token
+// tile vs tile 
+// token vs tile
+// avoid cluttering getSortingRule() and improve code readability
+function comparePairings(sprite,sibling){
+  if(sprite.type === "Token" && sibling.type === "Token"){
+    return "Tokens"
+  } else if(sprite.type === "Tile" && sibling.type === "Tile"){
+    return "Tiles"
+  } else {
+    return "Mixed"
+  }
+}
+
 // compare a sprite and its sibling and return what sorting rule based if:
 // ... if the sibling is a token : sort by vertical depth --done 
 // ... if the sibling is a token inside a region with linked walls : sort the linked walls behind the token -- todo
-// ... if the sibling is a tile : compare depth based on their facing -- wip
+// ... if the sibling is a tile : compare depth based on their facing and if they are flipped -- wip
+//     ... if a sibling is not flipped , and its sortrule is "X" , sort by X
+//     ... if a sibling is not flipped , and its sortrule is "Y" , sort by Y
+//     ... if a sibling is flipped , and its sortrule is "X" , sort by Y instead of X because while its facing should be SW to NE , its art is flipped and so it appear facing SE to NW instead
+//     ... if a sibling is flipped , and its sortrule is "Y" , sort by X instead of Y because while its facing should be SE to NW , its art is flipped and so it appear facing SW to NE instead
 // 
 function getSortingRule(sprite,sibling){
-  // console.log("SPRITE SORTING RULES", sprite.sortRule, "SIBLING SORTING RULES", sibling.sortRule)
-  if(sibling.type === "Token"){
-    const depthA = sprite.y - sprite.x;
-    const depthB = sibling.y - sibling.x;
-    return depthA - depthB;
-  } else if(sibling.type === "Tile"){
-    // console.log("isTileFlipped(sprite)", isTileFlipped(sprite))
-    if(!isTileFlipped(sibling)){
-      if(sibling.sortRule === "X"){
-        if(sprite.name === "sw front" && sibling.name === "sw back"){
-          console.log("NOT FLIPPED SPRITE SORT BY X", isTileFlipped(sprite),isTileFlipped(sibling));
-        }
-        return sibling.x - sprite.x;
-      } else {
-        if(sprite.name === "sw front" && sibling.name === "sw back"){
-          console.log("NOT FLIPPED SPRITE SORT BY Y");
-        }
-        return sprite.y - sibling.y;
-      }
-    } else {
-      if(sibling.sortRule === "X"){
-        if(sprite.name === "nw front" && sibling.name === "nw back"){
-          console.log("FLIPPED SPRITE SORT BY X");
-        }
-        return sibling.x - sprite.x;
-      } else {
-        if(sprite.name === "nw front" && sibling.name === "nw back"){
-          console.log("FLIPPED SPRITE SORT BY Y",isTileFlipped(sprite),isTileFlipped(sibling), sprite.sortRule, sibling.sortRule);
-        }
-        return sprite.y - sibling.y;
-      }
+  if(sibling.id !== sprite.id){ // never compare an object against itself
+    switch(comparePairings(sprite,sibling)){
+      case "Tokens":
+        return sortByDepth(sprite,sibling)
+        break;
+      case "Tiles":
+        // return sort by Y or X based on the tile facing property and if the tile is flipped
+        return isTileAxisFlipped(sibling)? sortByY(sprite,sibling) : sortByX(sibling,sprite);
+        break;
+      case "Mixed":
+        return isTileAxisFlipped(sibling)? sortByX(sprite,sibling) : sortByY(sprite,sibling);
+      default:
+        return sortByDepth(sprite,sibling)
+        break;
     }
   }
 }
 
-// function sortByX(spriteA, spriteB){
-//   if(spriteA.name === "sw front"){
-//     console.log("sw front: sort by X")
-//   }
-//   return spriteB.x - spriteA.x;
-// }
+function sortByX(sprite, sibling){
+  return sprite.x - sibling.x;
+}
 
-// function sortByY(spriteA, spriteB){
-//   if(spriteA.name === "sw front"){
-//     console.log("sw front: sort by Y")
-//   }
-//   return spriteA.y - spriteB.y;
-// }
+function sortByY(sprite, sibling){
+  return sprite.y - sibling.y;
+}
 
-function sortByRegion(spriteA, spriteB){
-  if(spriteA.name === "sw front"){
+function sortByDepth(sprite,sibling){
+  const depthA = sprite.y - sprite.x;
+  const depthB = sibling.y - sibling.x;
+  return depthA - depthB;
+}
+
+function sortByRegion(sprite, sibling){
+  if(sprite.name === "sw front"){
     console.log("sw front: sort by region")
   }
-  // console.log("SORT BY REGION: ")
-  if(spriteA.type === "Tile"){
+  if(sprite.type === "Tile"){
     return -1;
-  } else if (spriteB.type === "Tile"){
+  } else if (sibling.type === "Tile"){
     return 1;
   }
 }
-
-// tokens are sorted by depth
-// tiles are sorted by X or Y depending on what facing they have and what is their facing rule
-
-// function sortByDepth(sprite, sibling) {
-//   const depthA = sprite.y - sprite.x;
-//   const depthB = sibling.y - sibling.x;
-
-//   if(sprite.name === "sw front" && sibling.name === "sw back"){
-//     console.log("sw front: sort by depth", depthA, depthB , "DIFF:", depthA - depthB , "WITH", sibling.name)
-//     if (depthA > depthB) {
-//       if(sibling)
-//       console.log("HIGHER")
-//       return getSortingRule(sprite, sibling);
-//     } else {
-//       console.log("LOWER")
-//     }
-//   }
-//   return getSortingRule(sprite, sibling)
-// }
 
 function isRegionMatching (sprite, sibling){
   if(sprite.occupiedRegion !== null && sibling.linkedRegion !== null){
@@ -491,12 +469,13 @@ function sortableSprite(sprite){
   let anchorY = sprite.object.document.y;
   let tileMirrorHorizontal = null;
   const tileFacing = sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID, 'tileFacing') ?? DEFAULT_TILE_FACING;
-  const sortRule = TILE_FACINGS.find( tile => tile.facing === tileFacing).sortingRule;
 
+  const sortRule = TILE_FACINGS.find( tile => tile.facing === tileFacing).sortingRule;
+  
   if (game.modules.get(fastFlipCompatiility.MODULE_ID)?.active){
     tileMirrorHorizontal = sprite.object.document.getFlag(fastFlipCompatiility.MODULE_ID, fastFlipCompatiility.TILE_MIRROR_HORIZONTAL)
   }
-
+  
   const tileFlipped = sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID, 'tileFlipped')?sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID,'tileFlipped') : null;
   
   const height = sprite.object.document.height;
@@ -506,6 +485,8 @@ function sortableSprite(sprite){
   if(!newLinkedRegion){newLinkedRegion = null};
   if(!newOccupiedRegion){newOccupiedRegion = null};
   
+  // console.log("TILE RULES: " , name , sortRule, tileFlipped , tileMirrorHorizontal);
+
   return {
     id:id,
     type:type,

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -1,4 +1,8 @@
-import { isometricModuleConfig,fastFlipCompatiility } from './consts.js';
+import { 
+  isometricModuleConfig,
+  fastFlipCompatiility,
+  DEFAULT_TILE_FACING
+} from './consts.js';
 // Função auxiliar para converter coordenadas isométricas para cartesianas
 export function isoToCartesian(isoX, isoY) {
   const angle = Math.PI / 4; // 45 graus em radianos
@@ -205,24 +209,16 @@ function isTileFlipped(sprite){
   return result;
 }
 
-// ties in y still cause values cause flicker
-// multiples tokens canc ause the logic to break sometimes for some reason
-
 function sortByX(spriteA, spriteB){
-  // if (spriteA.name === "human witch" || spriteA.name === "human witch"){
-  //   console.log("WITCH SORT BY X:", spriteA.name, spriteB.name, spriteA.x - spriteB.x)
-  // }
   return spriteB.x - spriteA.x;
 }
 
 function sortByY(spriteA, spriteB){
-  // if (spriteA.name === "human witch" || spriteA.name === "human witch"){
-  //   console.log("WITCH SORT BY Y:", spriteA.name, spriteB.name, spriteA.y - spriteB.y)
-  // }
   return spriteA.y - spriteB.y;
 }
 
 function sortByRegion(spriteA, spriteB){
+  // console.log("SORT BY REGION: ")
   if(spriteA.type === "Tile"){
     return -1;
   } else if (spriteB.type === "Tile"){
@@ -230,26 +226,20 @@ function sortByRegion(spriteA, spriteB){
   }
 }
 
-// i think further refinement is required here
-// like a tie breaker that either look on the X or Y axis difference if both are on the same vertical height , 
-// for example if a tile is flipped , compare with y axis , if not , compare with x axis 
-
 function sortByDepth(spriteA, spriteB) {
   const depthA = spriteA.y - spriteA.x;
   const depthB = spriteB.y - spriteB.x;
 
   if (depthA === depthB) {
-    // tie breaker here
+    // tie breaker based on tile facing
     if(isBothTile(spriteA, spriteB)){
-      // at this point i need to add an UI element that will indicate from which axis a tile should be sorted based on its art
-      // if(isTileFlipped(spriteA)){
-      //   return 
-      // }
+      if(spriteA.tileFacing === "south east to north west" && !isTileFlipped(spriteA)){
+        return sortByX(spriteA, spriteB)
+      } else {
+        return sortByY(spriteA, spriteB);
+      }
     }
-      return spriteA.y - spriteB.y;
-  }
-  if (spriteA.name === "human witch" || spriteA.name === "human witch"){
-    console.log("WITCH SORT DEPTH", depthA - depthB)
+    return spriteA.y - spriteB.y;
   }
   return depthA - depthB;
 }
@@ -452,7 +442,8 @@ function sortableSprite(sprite){
   let anchorX = sprite.object.document.x;
   let anchorY = sprite.object.document.y;
   let tileMirrorHorizontal = null;
-  
+  const tileFacing = sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID, 'tileFacing') ?? DEFAULT_TILE_FACING;
+
   if (game.modules.get(fastFlipCompatiility.MODULE_ID)?.active){
     tileMirrorHorizontal = sprite.object.document.getFlag(fastFlipCompatiility.MODULE_ID, fastFlipCompatiility.TILE_MIRROR_HORIZONTAL)
   }
@@ -466,7 +457,6 @@ function sortableSprite(sprite){
   if(!newLinkedRegion){newLinkedRegion = null};
   if(!newOccupiedRegion){newOccupiedRegion = null};
   
-
   return {
     id:id,
     type:type,
@@ -498,20 +488,23 @@ export function debugCanvasLayer(spriteList){
       let newOccupiedRegion = sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID, 'currentRegion');
       if(!newLinkedRegion){newLinkedRegion = null;}
       if(!newOccupiedRegion){newOccupiedRegion = null;}
+      const tileFacing = sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID, 'tileFacing') ?? DEFAULT_TILE_FACING;
+
       data.push({
         // id: sprite.object.document.id,
         // type: sprite.object.document.documentName,
         name: sprite.object.document.name? sprite.object.document.name : "no name",
         //sprite.documentName === "Tile"? (sprite.x) - (sprite.width *0.25) : sprite.x,
-        x: anchorX,
-        y: anchorY,
+        // x: anchorX,
+        // y: anchorY,
         // sortLayer: sprite.sortLayer, 
         // sort: sprite.sort,
         // linkedRegion:newLinkedRegion,
         // occupiedRegion: newOccupiedRegion,
         // occupiedRegion: sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID, 'currentRegion')? sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID, 'currentRegion') : "none",
-        tileMirrorHorizontal: sprite.object.document.getFlag(fastFlipCompatiility.MODULE_ID, fastFlipCompatiility.TILE_MIRROR_HORIZONTAL)?sprite.object.document.getFlag(fastFlipCompatiility.MODULE_ID, fastFlipCompatiility.TILE_MIRROR_HORIZONTAL) : null,
-        tileFlipped: sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID, 'tileFlipped')?sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID,'tileFlipped') : null,
+        // tileMirrorHorizontal: sprite.object.document.getFlag(fastFlipCompatiility.MODULE_ID, fastFlipCompatiility.TILE_MIRROR_HORIZONTAL)?sprite.object.document.getFlag(fastFlipCompatiility.MODULE_ID, fastFlipCompatiility.TILE_MIRROR_HORIZONTAL) : null,
+        // tileFlipped: sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID, 'tileFlipped')?sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID,'tileFlipped') : null,
+        tileFacing: tileFacing
       })
     });
     console.table(data)

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -1,6 +1,7 @@
 import { 
   isometricModuleConfig,
   fastFlipCompatiility,
+  TILE_FACINGS,
   DEFAULT_TILE_FACING
 } from './consts.js';
 // Função auxiliar para converter coordenadas isométricas para cartesianas
@@ -124,6 +125,8 @@ export function sortPlaceableByPosition(placeable) {
     return canvasLayer
     .filter( sprite => sprite.sortLayer === placeableMeshLayer)
     .toSorted((sprite,sibling)=> compareSpriteByPosition(sprite,sibling));
+
+    // starting to think the sorting algorithm cause side effects 
   }
 }
 
@@ -169,37 +172,28 @@ function compareSpriteByPosition(sprite,sibling){
   // for cases with tiles linked to a region with region sort enabled.
   if(isRegionMatching(currentSprite,currentSibling)){
     sortChange = sortByRegion(currentSprite,currentSibling);
-  // for cases involving one token and one tile
-  } else if (isTokenAndTile(currentSprite , currentSibling) ) {
-    // for cases where a tile is flipped
-    if(isTileFlipped(currentSprite) || isTileFlipped(currentSibling)){
-      sortChange = sortByX(currentSprite,currentSibling); // sort by X axis if the tile is not flipped
-    } else {
-      sortChange = sortByY(currentSprite,currentSibling); // sort by Y axis if the tile is flipped
-    }
-  // for cases where both placables are of the same type and none of them are flipped
-  } else if(!isTileFlipped(currentSprite) || !isTileFlipped(currentSibling)){
-    sortChange = sortByDepth(currentSprite,currentSibling);
+  } else {
+    sortChange = getSortingRule(currentSprite,currentSibling);
   }
   return sortChange;
 }
 
 // bit overkill but make code much more readable and avoid duplicate compar logic
-function isTokenAndTile(spriteA, spriteB){
-  let result = false;
-  if(spriteA.type ==="Token" && spriteB.type ==="Tile" || spriteA.type ==="Tile" && spriteB.type ==="Token"){
-    result = true;
-  }
-  return result;
-}
+// function isTokenAndTile(spriteA, spriteB){
+//   let result = false;
+//   if(spriteA.type ==="Token" && spriteB.type ==="Tile" || spriteA.type ==="Tile" && spriteB.type ==="Token"){
+//     result = true;
+//   }
+//   return result;
+// }
 
-function isBothTile(spriteA, spriteB){
-  let result = false;
-  if(spriteA.type ==="Tile" && spriteB.type ==="Tile"){
-    result = true;
-  }
-  return result;
-}
+// function isBothTile(spriteA, spriteB){
+//   let result = false;
+//   if(spriteA.type ==="Tile" && spriteB.type ==="Tile"){
+//     result = true;
+//   }
+//   return result;
+// }
 
 function isTileFlipped(sprite){
   let result = false;
@@ -209,15 +203,65 @@ function isTileFlipped(sprite){
   return result;
 }
 
-function sortByX(spriteA, spriteB){
-  return spriteB.x - spriteA.x;
+// compare a sprite and its sibling and return what sorting rule based if:
+// ... if the sibling is a token : sort by vertical depth --done 
+// ... if the sibling is a token inside a region with linked walls : sort the linked walls behind the token -- todo
+// ... if the sibling is a tile : compare depth based on their facing -- wip
+// 
+function getSortingRule(sprite,sibling){
+  // console.log("SPRITE SORTING RULES", sprite.sortRule, "SIBLING SORTING RULES", sibling.sortRule)
+  if(sibling.type === "Token"){
+    const depthA = sprite.y - sprite.x;
+    const depthB = sibling.y - sibling.x;
+    return depthA - depthB;
+  } else if(sibling.type === "Tile"){
+    // console.log("isTileFlipped(sprite)", isTileFlipped(sprite))
+    if(!isTileFlipped(sibling)){
+      if(sibling.sortRule === "X"){
+        if(sprite.name === "sw front" && sibling.name === "sw back"){
+          console.log("NOT FLIPPED SPRITE SORT BY X", isTileFlipped(sprite),isTileFlipped(sibling));
+        }
+        return sibling.x - sprite.x;
+      } else {
+        if(sprite.name === "sw front" && sibling.name === "sw back"){
+          console.log("NOT FLIPPED SPRITE SORT BY Y");
+        }
+        return sprite.y - sibling.y;
+      }
+    } else {
+      if(sibling.sortRule === "X"){
+        if(sprite.name === "nw front" && sibling.name === "nw back"){
+          console.log("FLIPPED SPRITE SORT BY X");
+        }
+        return sibling.x - sprite.x;
+      } else {
+        if(sprite.name === "nw front" && sibling.name === "nw back"){
+          console.log("FLIPPED SPRITE SORT BY Y",isTileFlipped(sprite),isTileFlipped(sibling), sprite.sortRule, sibling.sortRule);
+        }
+        return sprite.y - sibling.y;
+      }
+    }
+  }
 }
 
-function sortByY(spriteA, spriteB){
-  return spriteA.y - spriteB.y;
-}
+// function sortByX(spriteA, spriteB){
+//   if(spriteA.name === "sw front"){
+//     console.log("sw front: sort by X")
+//   }
+//   return spriteB.x - spriteA.x;
+// }
+
+// function sortByY(spriteA, spriteB){
+//   if(spriteA.name === "sw front"){
+//     console.log("sw front: sort by Y")
+//   }
+//   return spriteA.y - spriteB.y;
+// }
 
 function sortByRegion(spriteA, spriteB){
+  if(spriteA.name === "sw front"){
+    console.log("sw front: sort by region")
+  }
   // console.log("SORT BY REGION: ")
   if(spriteA.type === "Tile"){
     return -1;
@@ -226,23 +270,25 @@ function sortByRegion(spriteA, spriteB){
   }
 }
 
-function sortByDepth(spriteA, spriteB) {
-  const depthA = spriteA.y - spriteA.x;
-  const depthB = spriteB.y - spriteB.x;
+// tokens are sorted by depth
+// tiles are sorted by X or Y depending on what facing they have and what is their facing rule
 
-  if (depthA === depthB) {
-    // tie breaker based on tile facing
-    if(isBothTile(spriteA, spriteB)){
-      if(spriteA.tileFacing === "south east to north west" && !isTileFlipped(spriteA)){
-        return sortByX(spriteA, spriteB)
-      } else {
-        return sortByY(spriteA, spriteB);
-      }
-    }
-    return spriteA.y - spriteB.y;
-  }
-  return depthA - depthB;
-}
+// function sortByDepth(sprite, sibling) {
+//   const depthA = sprite.y - sprite.x;
+//   const depthB = sibling.y - sibling.x;
+
+//   if(sprite.name === "sw front" && sibling.name === "sw back"){
+//     console.log("sw front: sort by depth", depthA, depthB , "DIFF:", depthA - depthB , "WITH", sibling.name)
+//     if (depthA > depthB) {
+//       if(sibling)
+//       console.log("HIGHER")
+//       return getSortingRule(sprite, sibling);
+//     } else {
+//       console.log("LOWER")
+//     }
+//   }
+//   return getSortingRule(sprite, sibling)
+// }
 
 function isRegionMatching (sprite, sibling){
   if(sprite.occupiedRegion !== null && sibling.linkedRegion !== null){
@@ -380,6 +426,8 @@ export function toggleAnchorAxis(object,toggle){
 }
 
 // used to debug visually a point on the tile selection box's footprint but its bugged, should fix later
+// IMPROVEMENT: draw the gizmo in a way to indicate which axis a tile is facing 
+// other improvement : instead of a drop down, two floating arrow buttons setting the facing that appear when the tile is controlled
 function drawTileAnchorLines(objectAnchor) {
   // Removes existing lines
   cleanupTileAnchorLines();
@@ -443,6 +491,7 @@ function sortableSprite(sprite){
   let anchorY = sprite.object.document.y;
   let tileMirrorHorizontal = null;
   const tileFacing = sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID, 'tileFacing') ?? DEFAULT_TILE_FACING;
+  const sortRule = TILE_FACINGS.find( tile => tile.facing === tileFacing).sortingRule;
 
   if (game.modules.get(fastFlipCompatiility.MODULE_ID)?.active){
     tileMirrorHorizontal = sprite.object.document.getFlag(fastFlipCompatiility.MODULE_ID, fastFlipCompatiility.TILE_MIRROR_HORIZONTAL)
@@ -473,6 +522,7 @@ function sortableSprite(sprite){
     occupiedRegion: newOccupiedRegion,
     tileMirrorHorizontal: tileMirrorHorizontal,
     tileFlipped: tileFlipped,
+    sortRule:sortRule,
   }
 }
 
@@ -481,9 +531,6 @@ export function debugCanvasLayer(spriteList){
     const data = []
 
     spriteList.map(sprite => {
-      let anchorX = sprite.object.document.x;
-      let anchorY = sprite.object.document.y;
-
       let newLinkedRegion = sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID, 'regionLink');
       let newOccupiedRegion = sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID, 'currentRegion');
       if(!newLinkedRegion){newLinkedRegion = null;}
@@ -495,15 +542,15 @@ export function debugCanvasLayer(spriteList){
         // type: sprite.object.document.documentName,
         name: sprite.object.document.name? sprite.object.document.name : "no name",
         //sprite.documentName === "Tile"? (sprite.x) - (sprite.width *0.25) : sprite.x,
-        // x: anchorX,
-        // y: anchorY,
+        x: sprite.object.document.x,
+        y: sprite.object.document.y,
         // sortLayer: sprite.sortLayer, 
         // sort: sprite.sort,
         // linkedRegion:newLinkedRegion,
         // occupiedRegion: newOccupiedRegion,
         // occupiedRegion: sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID, 'currentRegion')? sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID, 'currentRegion') : "none",
-        // tileMirrorHorizontal: sprite.object.document.getFlag(fastFlipCompatiility.MODULE_ID, fastFlipCompatiility.TILE_MIRROR_HORIZONTAL)?sprite.object.document.getFlag(fastFlipCompatiility.MODULE_ID, fastFlipCompatiility.TILE_MIRROR_HORIZONTAL) : null,
-        // tileFlipped: sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID, 'tileFlipped')?sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID,'tileFlipped') : null,
+        tileMirrorHorizontal: sprite.object.document.getFlag(fastFlipCompatiility.MODULE_ID, fastFlipCompatiility.TILE_MIRROR_HORIZONTAL)?sprite.object.document.getFlag(fastFlipCompatiility.MODULE_ID, fastFlipCompatiility.TILE_MIRROR_HORIZONTAL) : null,
+        tileFlipped: sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID, 'tileFlipped')?sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID,'tileFlipped') : null,
         tileFacing: tileFacing
       })
     });

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -165,14 +165,17 @@ function compareSpriteByPosition(sprite,sibling){
   // for cases with tiles linked to a region with region sort enabled.
   if(isRegionMatching(currentSprite,currentSibling)){
     sortChange = sortByRegion(currentSprite,currentSibling);
+  // for cases involving one token and one tile
   } else if (isTokenAndTile(currentSprite , currentSibling) ) {
+    // for cases where a tile is flipped
     if(isTileFlipped(currentSprite) || isTileFlipped(currentSibling)){
-      sortChange = sortByY(currentSprite,currentSibling); // sort by Y axis if the tile is flipped
-    } else {
       sortChange = sortByX(currentSprite,currentSibling); // sort by X axis if the tile is not flipped
+    } else {
+      sortChange = sortByY(currentSprite,currentSibling); // sort by Y axis if the tile is flipped
     }
-  } else {
-    sortChange = sortByVertical(currentSprite,currentSibling);
+  // for cases where both placables are of the same type and none of them are flipped
+  } else if(!isTileFlipped(currentSprite) || !isTileFlipped(currentSibling)){
+    sortChange = sortByDepth(currentSprite,currentSibling);
   }
   return sortChange;
 }
@@ -206,24 +209,17 @@ function isTileFlipped(sprite){
 // multiples tokens canc ause the logic to break sometimes for some reason
 
 function sortByX(spriteA, spriteB){
-  let result = 1;
-  if (spriteA.x >= spriteB.x) { result = -1;}
-  return result;
+  // if (spriteA.name === "human witch" || spriteA.name === "human witch"){
+  //   console.log("WITCH SORT BY X:", spriteA.name, spriteB.name, spriteA.x - spriteB.x)
+  // }
+  return spriteB.x - spriteA.x;
 }
 
 function sortByY(spriteA, spriteB){
-  if (spriteA.name === "glitched wall back" && spriteB.name === "glitched wall back"){
-    console.log("SORTED Y?")
-    console.log("A IS :", spriteA.name)
-    console.log("B IS:", spriteB.name)
-    console.log("IS TOKEN AND TILE?", isTokenAndTile(spriteA, spriteB))
-    console.log("IS BOTH TILES?", isBothTile(spriteA, spriteB))
-    console.log("IS A FLIPPED?", isTileFlipped(spriteA))
-    console.log("IS B FLIPPED?", isTileFlipped(spriteB))
-  }
-  let result = 1;
-  if (spriteA.y <= spriteB.y) { result = -1;}
-  return result;
+  // if (spriteA.name === "human witch" || spriteA.name === "human witch"){
+  //   console.log("WITCH SORT BY Y:", spriteA.name, spriteB.name, spriteA.y - spriteB.y)
+  // }
+  return spriteA.y - spriteB.y;
 }
 
 function sortByRegion(spriteA, spriteB){
@@ -234,21 +230,28 @@ function sortByRegion(spriteA, spriteB){
   }
 }
 
-function sortByVertical(spriteA, spriteB) {
-  if (spriteA.name === "glitched wall back" && spriteB.name === "glitched wall front"){
-    console.log("SORTED VERTICAL?")
-    console.log("A IS :", spriteA.name, "coords:", spriteA.x, spriteA.y)
-    console.log("B IS:", spriteB.name, "coords:", spriteB.x, spriteB.y)
-    console.log("IS TOKEN AND TILE?", isTokenAndTile(spriteA, spriteB))
-    console.log("IS BOTH TILES?", isBothTile(spriteA, spriteB))
-    console.log("IS A FLIPPED?", isTileFlipped(spriteA))
-    console.log("IS B FLIPPED?", isTileFlipped(spriteB))
-  }
-  let result = 1;
-    if(spriteA.x > spriteB.x && spriteA.y < spriteB.y){
-      result = -1;
+// i think further refinement is required here
+// like a tie breaker that either look on the X or Y axis difference if both are on the same vertical height , 
+// for example if a tile is flipped , compare with y axis , if not , compare with x axis 
+
+function sortByDepth(spriteA, spriteB) {
+  const depthA = spriteA.y - spriteA.x;
+  const depthB = spriteB.y - spriteB.x;
+
+  if (depthA === depthB) {
+    // tie breaker here
+    if(isBothTile(spriteA, spriteB)){
+      // at this point i need to add an UI element that will indicate from which axis a tile should be sorted based on its art
+      // if(isTileFlipped(spriteA)){
+      //   return 
+      // }
     }
-  return result;
+      return spriteA.y - spriteB.y;
+  }
+  if (spriteA.name === "human witch" || spriteA.name === "human witch"){
+    console.log("WITCH SORT DEPTH", depthA - depthB)
+  }
+  return depthA - depthB;
 }
 
 function isRegionMatching (sprite, sibling){

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -154,7 +154,6 @@ export function sortPlaceableByPosition(placeable) {
   }
 }
 
-
 /**
  * compare two placeables by Y positions if one of the placable is a tile that is flipped
  * otherwise compare them by x positions.
@@ -175,29 +174,10 @@ function compareSiblingPosition(sprite,sibling){
   if(isRegionMatching(currentSprite,currentSibling)){
     sortChange = sortByRegion(currentSprite,currentSibling);
   } else {
-    sortChange = getSortingRule(currentSprite,currentSibling);
+    // debugSort(currentSprite,currentSibling)
+    sortChange = sortByFacing(currentSprite,currentSibling);
   }
   return sortChange;
-}
-
-function isTileFlipped (sprite){
-  let result = false;
-  if(sprite.tileMirrorHorizontal || sprite.tileFlipped){
-    result = true;
-  }
-  return result;
-}
-
-// return true or false based on if a tile sortRule is by X or by Y axis and invert the result if the tile is also flipped 
-// other result always return false because no axis check is needed and such tiles are always sorted by vertical depth.
-function isTileAxisFlipped(sprite){
-  if(sprite.sortRule === "X"){
-    return isTileFlipped(sprite)? true : false;
-  } else if (sprite.sortRule === "Y"){
-    return isTileFlipped(sprite)? true : false;
-  } else {
-    return false;
-  }
 }
 
 // compare cases where the placeable type is: 
@@ -206,64 +186,96 @@ function isTileAxisFlipped(sprite){
 // token vs tile
 // avoid cluttering getSortingRule() and improve code readability
 function comparePairings(sprite,sibling){
-  if(sprite.type === "Token" && sibling.type === "Token"){
-    return "Tokens"
-  } else if(sprite.type === "Tile" && sibling.type === "Tile"){
-    return "Tiles"
-  } else {
-    return "Mixed"
+  if(isToken(sprite) && isToken(sibling)){
+    return "Token-Token";
+  } else if(isTile(sprite) && isTile(sibling)){
+    return "Tile-Tile";
+  } else if(isTile(sprite) && isToken(sibling)){
+    return "Tile-Token";
+  } else if(isToken(sprite) && isTile(sibling)){
+    return "Token-Tile";
   }
 }
 
-// compare a sprite and its sibling and return what sorting rule based if:
+// compare a sprite and its sibling and return the right sorting rule based on:
 // ... if the sibling is a token : sort by vertical depth --done 
 // ... if the sibling is a token inside a region with linked walls : sort the linked walls behind the token -- todo
 // ... if the sibling is a tile : compare depth based on their facing and if they are flipped -- wip
-//     ... if a sibling is not flipped , and its sortrule is "X" , sort by X
-//     ... if a sibling is not flipped , and its sortrule is "Y" , sort by Y
-//     ... if a sibling is flipped , and its sortrule is "X" , sort by Y instead of X because while its facing should be SW to NE , its art is flipped and so it appear facing SE to NW instead
-//     ... if a sibling is flipped , and its sortrule is "Y" , sort by X instead of Y because while its facing should be SE to NW , its art is flipped and so it appear facing SW to NE instead
-// 
-function getSortingRule(sprite,sibling){
-  if(sibling.id !== sprite.id){ // never compare an object against itself
-    switch(comparePairings(sprite,sibling)){
-      case "Tokens":
-        return sortByDepth(sprite,sibling)
+//     ... if a sibling is  a tile and is facing south west , sort on the y axis
+//     ... if a sibling is  a tile and is facing south east , sort on the x axis
+function sortByFacing(spriteToSort, siblingToCompare){
+  if(spriteToSort.id !== siblingToCompare.id){ // never compare an object against itself
+    switch(comparePairings(spriteToSort,siblingToCompare)){
+      case "Token-Token":
+        // tokens are always sorted by x/y depth against each others
+        return spriteToSort.isoDepth - siblingToCompare.isoDepth; // other cases dont need complex rules, simply compare by vertical position on the screen
         break;
-      case "Tiles":
-        // return sort by Y or X based on the tile facing property and if the tile is flipped
-        return isTileAxisFlipped(sibling)? sortByY(sprite,sibling) : sortByX(sibling,sprite);
+      case "Tile-Tile":
+        // tiles have a bit more complex logic , especially if they have a large width, so tiles are compared by a perpendicular X axis or Y axis
+        // this take in account a tile facing and if its flipped , 
+        switch(getFacing(siblingToCompare)){ 
+          case 'south west':
+            return siblingToCompare.x - spriteToSort.x 
+            break;
+          case 'south east':
+            return spriteToSort.y - siblingToCompare.y 
+            break;
+          default:
+            return spriteToSort.isoDepth - siblingToCompare.isoDepth; 
+        }
         break;
-      case "Mixed":
-        return isTileAxisFlipped(sibling)? sortByX(sprite,sibling) : sortByY(sprite,sibling);
+        // Tile vs Token , where spriteToSort is the tile and siblingToCompare is the token
+        case "Tile-Token":
+        switch(getFacing(spriteToSort)){ 
+          case 'south west':
+            return siblingToCompare.x - spriteToSort.x 
+            break;
+          case 'south east':
+            return spriteToSort.y - siblingToCompare.y 
+            break;
+          default:
+            return spriteToSort.isoDepth - siblingToCompare.isoDepth; 
+        }  
+          break;
+        // Token vs Tile , where siblingToCompare is the tile and spriteToSort is the token // 
+        case "Token-Tile":
+          switch(getFacing(siblingToCompare)){  // ---
+            case 'south west':
+              return siblingToCompare.x - spriteToSort.x 
+              break;
+            case 'south east':
+              return spriteToSort.y - siblingToCompare.y 
+              break;
+            default:
+              return spriteToSort.isoDepth - siblingToCompare.isoDepth; 
+          }  
+          break;
       default:
-        return sortByDepth(sprite,sibling)
+        return spriteToSort.isoDepth - siblingToCompare.isoDepth; 
         break;
+    }
+    if(isTile(siblingToCompare) && isToken(spriteToSort)){ // if the sibling is a tile, it need to be compared based on which way its facing
+      // a tile with a diagonal facing ( south east / south west ) is compared on the axis perpendicular to its visual length on an isometric plane.
+      switch(getFacing(siblingToCompare)){ 
+        case 'south west':
+          return siblingToCompare.x - spriteToSort.x // compare with the x axis if the sibling is facing southwest
+          break;
+        case 'south east':
+          return siblingToCompare.y - spriteToSort.y // compare with the x axis if the sibling is facing southeast
+          break;
+        default:
+          return spriteToSort.isoDepth - siblingToCompare.isoDepth; // other cases dont need complex rules, simply compare by vertical position on the screen
+      }
+    } else {
+      return spriteToSort.isoDepth - siblingToCompare.isoDepth; // other cases dont need complex rules, simply compare by vertical position on the screen
     }
   }
 }
 
-function sortByX(sprite, sibling){
-  return sprite.x - sibling.x;
-}
-
-function sortByY(sprite, sibling){
-  return sprite.y - sibling.y;
-}
-
-function sortByDepth(sprite,sibling){
-  const depthA = sprite.y - sprite.x;
-  const depthB = sibling.y - sibling.x;
-  return depthA - depthB;
-}
-
 function sortByRegion(sprite, sibling){
-  if(sprite.name === "sw front"){
-    console.log("sw front: sort by region")
-  }
-  if(sprite.type === "Tile"){
+  if(isTile(sprite)){
     return -1;
-  } else if (sibling.type === "Tile"){
+  } else if (isTile(sibling)){
     return 1;
   }
 }
@@ -450,16 +462,54 @@ function cleanupTileAnchorLines() {
 };
 
 
+function isTile(sprite){
+  return sprite.type == "Tile";
+}
+
+function isToken(sprite){
+  return sprite.type == "Token";
+}
+
+function isTileFlipped (sprite){
+  let result = false;
+  if(sprite.tileMirrorHorizontal || sprite.tileFlipped){
+    result = true;
+  }
+  return result;
+}
+
+// console.log("FLIPPED?", sprite.name , isTileFlipped(sprite), isTileFlipped(sprite)? 'south east' : 'south west') 
+
+//return a tile true facing in case the tile is in a flipped state if the initial facing is south west or south
+function getFacing(sprite) {
+  if(!isTile(sprite)) return null;
+  switch(sprite.tileFacing){
+    case 'south west':
+      return isTileFlipped(sprite)? 'south east' : 'south west';
+      break;
+    case 'south east':
+      return isTileFlipped(sprite)? 'south west' : 'south east';
+      break;
+    case 'south':
+      return 'south';
+      break;
+    case 'side':
+      return 'side';
+      break;
+    default:
+      return null;
+  }
+}
+
 /**
  * // a factory function that return a new object that contain all the relevant data required for depth sorting
+ * // notes : turn that into a class later
  * @param {*} sprite 
  * @returns 
  */
 
+// may seems overkill but passing the values directly sometimes cause weird "in between" value mutations that bricks sorting calculations
 function sortableSprite(sprite){
-  // may seems overkill but passing the values directly sometimes cause weird "in between" value mutations that bricks sorting calculations
-  // also can prepare the data based on some conditions or states, for example the right offset of tiles might change if a tile is flipped or not
-
   const id = sprite.object.document.id;
   const type = sprite.object.document.documentName;
   const name = sprite.object.document.name? sprite.object.document.name : "no name";
@@ -468,14 +518,10 @@ function sortableSprite(sprite){
   let anchorX = sprite.object.document.x;
   let anchorY = sprite.object.document.y;
   let tileMirrorHorizontal = null;
-  const tileFacing = sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID, 'tileFacing') ?? DEFAULT_TILE_FACING;
-
-  const sortRule = TILE_FACINGS.find( tile => tile.facing === tileFacing).sortingRule;
-  
+  const tileFacing = sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID, 'tileFacing') ?? DEFAULT_TILE_FACING;    
   if (game.modules.get(fastFlipCompatiility.MODULE_ID)?.active){
     tileMirrorHorizontal = sprite.object.document.getFlag(fastFlipCompatiility.MODULE_ID, fastFlipCompatiility.TILE_MIRROR_HORIZONTAL)
   }
-  
   const tileFlipped = sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID, 'tileFlipped')?sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID,'tileFlipped') : null;
   
   const height = sprite.object.document.height;
@@ -484,8 +530,6 @@ function sortableSprite(sprite){
   let newOccupiedRegion = sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID, 'currentRegion');
   if(!newLinkedRegion){newLinkedRegion = null};
   if(!newOccupiedRegion){newOccupiedRegion = null};
-  
-  // console.log("TILE RULES: " , name , sortRule, tileFlipped , tileMirrorHorizontal);
 
   return {
     id:id,
@@ -493,8 +537,7 @@ function sortableSprite(sprite){
     name: name,
     x: x,
     y: y,
-    anchorX: anchorX,
-    anchorY: anchorY,
+    isoDepth: y-x,
     height:height,
     width:width,
     forceSortBelow: false,
@@ -503,20 +546,52 @@ function sortableSprite(sprite){
     occupiedRegion: newOccupiedRegion,
     tileMirrorHorizontal: tileMirrorHorizontal,
     tileFlipped: tileFlipped,
-    sortRule:sortRule,
+    tileFacing:tileFacing,
+  }
+}
+
+function debugSort(sprite,sibling){
+  if(sprite.id !== sibling.id){
+    const data = {
+      sprite:{
+        value: sprite.name,
+        result: sprite.type,
+        facing: getFacing(sprite),
+      },
+      sibling:{
+        value: sibling.name,
+        result: sibling.type,
+        facing: getFacing(sibling),
+      },
+      sort:{
+        value: sortByFacing(sprite, sibling)
+      }
+    };
+    console.table(data);
   }
 }
 
 // for debugging canvasLayers 
 export function debugCanvasLayer(spriteList){
-    const data = []
+    const data = [];
 
     spriteList.map(sprite => {
       let newLinkedRegion = sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID, 'regionLink');
       let newOccupiedRegion = sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID, 'currentRegion');
       if(!newLinkedRegion){newLinkedRegion = null;}
       if(!newOccupiedRegion){newOccupiedRegion = null;}
+      let tileMirrorHorizontal = null;
       const tileFacing = sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID, 'tileFacing') ?? DEFAULT_TILE_FACING;
+      if (game.modules.get(fastFlipCompatiility.MODULE_ID)?.active){
+        tileMirrorHorizontal = sprite.object.document.getFlag(fastFlipCompatiility.MODULE_ID, fastFlipCompatiility.TILE_MIRROR_HORIZONTAL)
+      }
+      const tileFlipped = sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID, 'tileFlipped')?sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID,'tileFlipped') : null; 
+      const trueFacing = getFacing({
+        type: sprite.object.document.documentName,
+        tileFacing: tileFacing,
+        tileFlipped: tileFlipped,
+        tileMirrorHorizontal:tileMirrorHorizontal
+      })
 
       data.push({
         // id: sprite.object.document.id,
@@ -530,9 +605,10 @@ export function debugCanvasLayer(spriteList){
         // linkedRegion:newLinkedRegion,
         // occupiedRegion: newOccupiedRegion,
         // occupiedRegion: sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID, 'currentRegion')? sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID, 'currentRegion') : "none",
-        tileMirrorHorizontal: sprite.object.document.getFlag(fastFlipCompatiility.MODULE_ID, fastFlipCompatiility.TILE_MIRROR_HORIZONTAL)?sprite.object.document.getFlag(fastFlipCompatiility.MODULE_ID, fastFlipCompatiility.TILE_MIRROR_HORIZONTAL) : null,
-        tileFlipped: sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID, 'tileFlipped')?sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID,'tileFlipped') : null,
-        tileFacing: tileFacing
+        // tileMirrorHorizontal: sprite.object.document.getFlag(fastFlipCompatiility.MODULE_ID, fastFlipCompatiility.TILE_MIRROR_HORIZONTAL)?sprite.object.document.getFlag(fastFlipCompatiility.MODULE_ID, fastFlipCompatiility.TILE_MIRROR_HORIZONTAL) : null,
+        // tileFlipped: sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID, 'tileFlipped')?sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID,'tileFlipped') : null,
+        // tileFacing: tileFacing,
+        trueFacing : trueFacing
       })
     });
     console.table(data)

--- a/templates/tile-config.hbs
+++ b/templates/tile-config.hbs
@@ -10,6 +10,19 @@
         <input id="{{rootId}}-isometric-perspective-enable-tile-isometrics-tile-sorting" type="checkbox" name="flags.isometric-perspective.isoTileAutoSortingEnabled" {{checked document.flags.isometric-perspective.isoTileAutoSortingEnabled}}>
     </div>
 
+    <!-- Tile facing-->
+    <div class="form-group">
+        <label>{{localize 'isometric-perspective.tile_set_tile_facing'}}</label>
+        <div class="form-fields">
+        <select id="{{rootId}}-isometric-perspective-tile-facing" name="flags.isometric-perspective.tileFacing">
+            {{#each tileFacing}}
+                <option value="{{this}}" {{#if (eq this ../document.flags.isometric-perspective.tileFacing)}}selected{{/if}}>{{this}}</option>
+            {{/each}}
+            </select>
+        </div>
+        <p class="hint">{{localize 'isometric-perspective.tile_set_tile_facing_hint'}}</p>          
+    </div>
+
     <div class="form-group">
         <label for="{{rootId}}-isometric-perspective-enable-offset-gizmo">{{localize 'isometric-perspective.tile_enableIsometric_anchor_gizmo'}}</label>
         <input id="{{rootId}}-isometric-perspective-enable-offset-gizmo" type="checkbox" name="flags.isometric-perspective.isoOffsetGizmoEnabled" {{checked document.flags.isometric-perspective.isoOffsetGizmoEnabled}}>


### PR DESCRIPTION
major rewrite of the placeable sorting logic, but a lot of work whent under the hood to make the code more human readable and easier to reason.
added a few fancy debug tools as well
fixed a crash when opening tiles and regions palettes
fixed inconsistencies with tile facing , there is a new functionality that will calculate a tile true facing regardless of its flipped state as long as its facing matches whats on the original art asset.
tokens now seems to sort themselves much better as well, among each others and among tiles as well 

known issues : still some flickering happening, but unlike previous versions , its not lingering and it sort itself out if you move a placeable around

region sorting still require a fix

todo : 
improve the gizmo to be functional and not just a fancy line display for alignment. a good idea would be to add an arrow that display the current tile facing, add buttons to change the facing.

improve the tile palette UI , add iso offset , tile facing, scale maybe , etc.

<img width="1544" height="797" alt="image" src="https://github.com/user-attachments/assets/051aada1-a877-459f-8359-4e667066be1b" />
