### PR TITLE
Warpspeednyancat v14 update

### DIFF
--- a/scripts/autosorting.js
+++ b/scripts/autosorting.js
@@ -16,7 +16,6 @@ export function isoDepthSortTileMixin(Base){
       } else { 
         this.mesh.sortLayer = foundry.canvas.groups.PrimaryCanvasGroup.SORT_LAYERS.TILES; 
       }
-      // applyDepthSort(this);
     }
     _onUpdate(changed, options, userId) {
       super._onUpdate(changed, options, userId);
@@ -29,7 +28,7 @@ export function isoDepthSortTileMixin(Base){
         // if(!this.controlled){ // hide gizmo on unselected WIP
         //   toggleAnchorAxis(this.document, false);
         // }
-        applyDepthSort(this);
+        applyDepthSort();
       }      
       
     }
@@ -50,29 +49,33 @@ export function isoDepthSortTokenMixin(Base){
       }
     }
     
-    _refreshPosition(){
-      super._refreshPosition();
-      // console.log("done moving?")
-      applyDepthSort(this);
-     }
-
-    _onUpdate(changed, options, userId) {
-      super._onUpdate(changed, options, userId);
-      // applyDepthSort(this);
+    _onAnimationUpdate(changed, context){
+      super._onAnimationUpdate(changed, context);
+      if(changed.x || changed.y){
+        applyDepthSort();
+      }
     }
+
+    // keeping for now 
+    // _refreshPosition(){
+    //   super._refreshPosition();
+    //   // applyDepthSort();
+    //  }
+
+    // _onUpdate(changed, options, userId) {
+    //   super._onUpdate(changed, options, userId);
+    //   // applyDepthSort();
+    // }
   }
 }
 
-export function applyDepthSort(placeable){
-  const sortList = sortPlaceableByPosition(placeable) //.map(({sprite}) => sprite);
+export function applyDepthSort(){
+  const sortList = sortPlaceableByPosition() //.map(({sprite}) => sprite);
   // console.log("SORTLIST?", sortList)
-  for (let i = 0; i < sortList.length; i++) {
+  for (let i = 0; i < sortList.length ; i++) {
     const currentSprite = sortList[i].object;
-    
     currentSprite.mesh.sort = i; // if this is commented, tokens render above all tiles
     currentSprite.document.sort = i; // if this is commented, tokens render above SW tiles but under se tiles 
     // currentSprite.mesh.zIndex = i;
-
-    // console.log("currentSprite:", currentSprite.document.name,"sort:",currentSprite.document.sort,"X",currentSprite.document.x,"Y",currentSprite.document.y,"iso Depth",currentSprite.document.x - currentSprite.document.y )
   }
 }

--- a/scripts/autosorting.js
+++ b/scripts/autosorting.js
@@ -11,47 +11,34 @@ export function isoDepthSortTileMixin(Base){
 
     _refreshState() {
       super._refreshState();
-      
       const isTileSortable = this.document.flags[isometricModuleConfig.MODULE_ID]?.isoTileAutoSortingEnabled || false;
       if (isTileSortable){
         this.mesh.sortLayer = foundry.canvas.groups.PrimaryCanvasGroup.SORT_LAYERS.TOKENS; 
       } else { 
         this.mesh.sortLayer = foundry.canvas.groups.PrimaryCanvasGroup.SORT_LAYERS.TILES; 
       }
+      // applyDepthSort(this);
     }
     _onUpdate(changed, options, userId) {
       super._onUpdate(changed, options, userId);
-      if(this.zIndex){
-        this.zIndex = 0;
-        this.mesh.zIndex = 0;
-      }
       const isTileSortable = this.document.getFlag(isometricModuleConfig.MODULE_ID, 'isoTileAutoSortingEnabled');
       if(isTileSortable){
-        if ("y" in changed || "x" in changed) {
-          applyDepthSort();
-        }
-      }
-      
-      // if(this.controlled){ // show gizmo on selected
-      //   toggleAnchorAxis(this.document, true); 
-      // }
+        // if(this.controlled){ // show gizmo on selected WIP
+        //   toggleAnchorAxis(this.document, true); 
+        // }
 
-      // if(!this.controlled){ // hide gizmo on unselected
-      //   toggleAnchorAxis(this.document, false);
-      // }
+        // if(!this.controlled){ // hide gizmo on unselected WIP
+        //   toggleAnchorAxis(this.document, false);
+        // }
+        applyDepthSort(this);
+      }      
+      
     }
   }
 }
 
 export function isoDepthSortTokenMixin(Base){  
   return class DepthSortPlaceable extends Base{
-
-    /** 
-     * note: a single token move by one square trigger _refreshState() up to 5 times , 
-     * and a lot of other _onUpdate() can fire in between, _onUpdate() is usually one step behind _refreshState()
-     * _onUpdate()  and _refreshState() should never get mutual triggering code execution , otherwhise this cause an endless loop
-     * be warned! this will make your pc fan scream in pain!
-    */
 
     _refreshState() {
       super._refreshState();
@@ -62,24 +49,32 @@ export function isoDepthSortTokenMixin(Base){
       } else {
         this.document.setFlag(isometricModuleConfig.MODULE_ID, 'currentRegion', null);
       }
+      // applyDepthSort(this);
     }
 
     _onUpdate(changed, options, userId) {
       super._onUpdate(changed, options, userId);
-      if ("y" in changed || "x" in changed) {
-        applyDepthSort();
-      }
+      applyDepthSort(this);
     }
   }
 }
 
-export function applyDepthSort(){
-  const sortList = sortPlaceableByPosition();
+export function applyDepthSort(placeable){
+  const sortList = sortPlaceableByPosition(placeable);
   for (let i = 0; i < sortList.length; i++) {
-    const currentSprite = sortList[i];
-    currentSprite.object.document.sort = i;
-    currentSprite.sort = i;
+    const currentSprite = sortList[i].sprite;
+    
+    if(currentSprite.sort !== i){
+      console.log("sort changed:", currentSprite.object.document.name, "OLD:", currentSprite.sort,"NEW:", i)
+    }
+
+    currentSprite.sort = i; // if this is commented, tokens render above all tiles
+    currentSprite.object.document.sort = i; // if this is commented, tokens render above SW tiles but under se tiles 
+    currentSprite.zIndex = i;
+    currentSprite.object.zIndex = i;
+
+    // console.log("currentSprite", currentSprite.object.document.name,currentSprite.sort)
   }
-  debugCanvasLayer(sortList) //-------------------------------------------------------------------------- DEBUG!!!
-  canvas.primary.sortDirty = true;
+
+  // debugCanvasLayer(sortList) //-------------------------------------------------------------------------- DEBUG!!!
 }

--- a/scripts/autosorting.js
+++ b/scripts/autosorting.js
@@ -1,8 +1,7 @@
 import { isometricModuleConfig } from './consts.js';
 import { 
   sortPlaceableByPosition,
-  sortPlaceableByRegion,
-  debugCanvasLayer,
+  // debugCanvasLayer,
   toggleAnchorAxis
 } from './utils.js';
 
@@ -49,32 +48,31 @@ export function isoDepthSortTokenMixin(Base){
       } else {
         this.document.setFlag(isometricModuleConfig.MODULE_ID, 'currentRegion', null);
       }
-      // applyDepthSort(this);
     }
+    
+    _refreshPosition(){
+      super._refreshPosition();
+      // console.log("done moving?")
+      applyDepthSort(this);
+     }
 
     _onUpdate(changed, options, userId) {
       super._onUpdate(changed, options, userId);
-      applyDepthSort(this);
+      // applyDepthSort(this);
     }
   }
 }
 
 export function applyDepthSort(placeable){
-  const sortList = sortPlaceableByPosition(placeable);
+  const sortList = sortPlaceableByPosition(placeable) //.map(({sprite}) => sprite);
+  // console.log("SORTLIST?", sortList)
   for (let i = 0; i < sortList.length; i++) {
-    const currentSprite = sortList[i].sprite;
+    const currentSprite = sortList[i].object;
     
-    if(currentSprite.sort !== i){
-      console.log("sort changed:", currentSprite.object.document.name, "OLD:", currentSprite.sort,"NEW:", i)
-    }
+    currentSprite.mesh.sort = i; // if this is commented, tokens render above all tiles
+    currentSprite.document.sort = i; // if this is commented, tokens render above SW tiles but under se tiles 
+    // currentSprite.mesh.zIndex = i;
 
-    currentSprite.sort = i; // if this is commented, tokens render above all tiles
-    currentSprite.object.document.sort = i; // if this is commented, tokens render above SW tiles but under se tiles 
-    currentSprite.zIndex = i;
-    currentSprite.object.zIndex = i;
-
-    // console.log("currentSprite", currentSprite.object.document.name,currentSprite.sort)
+    // console.log("currentSprite:", currentSprite.document.name,"sort:",currentSprite.document.sort,"X",currentSprite.document.x,"Y",currentSprite.document.y,"iso Depth",currentSprite.document.x - currentSprite.document.y )
   }
-
-  // debugCanvasLayer(sortList) //-------------------------------------------------------------------------- DEBUG!!!
 }

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -284,7 +284,6 @@ Hooks.on("init", () => {
   CONFIG.Token.objectClass = isoDepthSortTokenMixin(CONFIG.Token.objectClass);
   CONFIG.Tile.objectClass = isoDepthSortTileMixin(CONFIG.Tile.objectClass);
 });
-Hooks.on("ready", applyDepthSort);
 
 /**
  * @param {----- TESTING AREA / ÁREA DE TESTES -----}

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -113,120 +113,164 @@ export function patchConfig(documentSheet, config, args) {
   }
 }
 
-export function sortPlaceableByRegion(placeable) {
-  if(placeable.mesh.sortLayer === foundry.canvas.groups.PrimaryCanvasGroup.SORT_LAYERS.TOKENS ){
-    const placeableMeshLayer = foundry.canvas.groups.PrimaryCanvasGroup.SORT_LAYERS.TOKENS;
-    const canvasLayer = canvas.primary.children;
-    const currentSortLayer = placeable.mesh.parent
-    return canvasLayer
-    .filter( sprite => sprite.sortLayer === placeableMeshLayer)
-    .toSorted((sprite,sibling)=> {
-      let compare = 0;
-      if( sprite.object.document.documentName === "Token" || sibling.object.document.documentName === "Token" ) {
-        if(sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID, 'currentRegion')){
-          compare = comparesiblingyRegion(sprite,sibling);
-        } else if (sibling.object.document.getFlag(isometricModuleConfig.MODULE_ID, 'currentRegion')) {
-          compare = comparesiblingyRegion(sprite,sibling);
-        }
-        return compare;
-      }
-    });
-
-  }
-}
-
-/**
- * change placeables sort values based on its y value on the grid compared to its siblings.
- * @param {Placeable|PlaceableDocument} placeable - The placeable document used as a reference for the sortlayer.
- */
-export function sortPlaceableByPosition(placeable) {
+// filter the sort layer into a new array of sortables, copy that array , sort the copy and return the result.
+export function sortPlaceableByPosition(placeable) { // might not need palceable later
+  console.clear()
   const placeableMeshLayer = foundry.canvas.groups.PrimaryCanvasGroup.SORT_LAYERS.TOKENS;
   const canvasLayer = canvas.primary.children;
-  const currentSortLayer = canvas.primary;
 
-  const sortList = [];
-  const filteredLayer = canvasLayer.filter( sprite => sprite.sortLayer === placeableMeshLayer)
-  // .map( sprite => {
-  for (let i = 0; i < filteredLayer.length; i++) {
-    if(placeable){
-      const currentSprite = sortableSprite(placeable.mesh);
-      const currentSibling = sortableSprite(filteredLayer[i]);
-      const sortScore = getSortScore(currentSprite,currentSibling);
-      console.log("sortScore", currentSibling.name, sortScore)
-      sortList.push({sibling:sprite, sortScore:sortScore});
-    }
-  }
+  const filteredLayer = canvasLayer.filter( sprite => {
+    return sprite.sortLayer === placeableMeshLayer && sprite.object.previewType === null;
+  }); // only need DepthSortPlaceables
+  // let layerToSort = filteredLayer.map(item => Object.assign({}, item));
+  let layerToSort = filteredLayer.map(item => Object.assign({}, item)).reverse();
 
-  // so now i got two depth score and i must sort the array by taking in account first the isoDepth
-  // then the perpendicularDepth if its not 0
-  // a depth score that is positive mean sorted above, negative means sorted below
+  layerToSort = layerToSort.toSorted((sprite,sibling) => {
+    const currentSprite = new SortableSprite(sprite);
+    const currentSibling = new SortableSprite(sibling);
+    return currentSprite.getSortOrder(currentSibling)
+  });
 
-  // probably mean i got to sort twice ... 
-
+  // might delete later
+  // for(let i = 0; i < layerToSort.length; i++){
+  //   const current = new SortableSprite(layerToSort[i]);
+  //   const next = new SortableSprite(layerToSort[i+1]);
+  //   if(current.isToken() && next.isNotNull()){
+  //     const sortScore = sortByFacing(next,current);
+  //     // console.log("IS TOKEN?", current.name , next.name , sortScore)
+  //   }
+  // }
+  
+  return layerToSort;
 }
 
-/**
- * compare two placeables by Y positions if one of the placable is a tile that is flipped
- * otherwise compare them by x positions.
- * this is due to the X axis being a diagonal from bottom left to top right ( acending)
- * an y being a diagonal from bottom riight to top left ( descending)
- *  y-      +x
- *    y-  x+
- *      o
- *    x-  y+
- * x-        y+
-*/
-// compare a sprite and its sibling and return the right sorting score based on:
-// ... if both are tokens : sort by vertical depth
-// ... if both are tiles : sort by facing but the order dosent matter.
-// ... if one is a tile and the other a token sort by facing but the tile always go first
-// ... if the token and the tiles share a region ID , region override the sortscore and always put the tiles behind the token.
-function getSortScore(sprite, sibling){
-  const token = isToken(sprite)? sprite : sibling;
-  const tile = isTile(sprite)? sprite : sibling;
-  if(isDifferentId(sprite,sibling)){ // never compare an object against itself
-    switch(comparePairings(sprite,sibling)){
-      case "Token-Token": // order dosent matter.
-      case "Tile-Tile": // order dosent matter, but the facing does.
-        return sortByFacing(sprite,sibling);
+// SortableSprite is a data class with some utility methods to avoid long chains of sprite.object.document.someValue in the code and overall make the 
+// sorting code a bit more readable. Also help isolate cases and avoid endless nesting comparaison, the utility methods always check for validiy as well.
+// isFacing() if its a tile, return the right facing state, taking in account if its flipped for SW and SE facings.
+// isTile() return true if its a tile, a bit shorter than doing a full comparaison everytime its needed.
+// isToken() return true if its a token, a bit shorter than doing a full comparaison everytime its needed.
+// isFlipped() return true if the tile is either flipped via the tileFlipped flag or if fast flip is installed , based on tileMirrorHorizontal in that case.
+// isRegionValid() because javascript will consider that null === null or undefined === undefined or "" === "" is as valid as iftwo region id match ... 
+// isNotNull() in case an invalid object is passed in the constructor, dosent break but marked as null , used when during the token sort correction when traversing the 
+// layerToSort if the token is at index 0 or at index layerToSort.length , again, used to make code a bit more readable and to rely less on "===" checks clutters everywhere.
+// getDebugData([args,...]) display SortableSprite props in a nice table for debugging purpose
+// getSortOrder(sibling) take another adjacent SortableSprite and compare their x , y or iso depth based on facing rules and return a positive or negative value to determine sort order:
+// a negative value indicate that the sibling should be sorted below 
+// a positive value indicate that the sibling should be sorted above
+// zero or NaN indicate a tie , no changes need to happen.
+// 
+export class SortableSprite {
+  constructor(placeable){
+    if(placeable){
+      this.id = placeable.object.document.id;
+      this.type = placeable.object.document.documentName;
+      this.name = placeable.object.document.name? placeable.object.document.name : "no name";
+      this.x = placeable.object.document.x;
+      this.y = placeable.object.document.y;
+      this.isoDepth = this.y - this.x;
+      this.facing = placeable.object.document.getFlag(isometricModuleConfig.MODULE_ID, 'tileFacing') ?? DEFAULT_TILE_FACING;
+      this.sort = placeable.object.document.sort;
+      this.tileFlipped = placeable.object.document.getFlag(isometricModuleConfig.MODULE_ID, 'tileFlipped')?placeable.object.document.getFlag(isometricModuleConfig.MODULE_ID,'tileFlipped') : null;
+      this.occupiedRegion = placeable.object.document.getFlag(isometricModuleConfig.MODULE_ID, 'currentRegion');
+      this.linkedRegion = placeable.object.document.getFlag(isometricModuleConfig.MODULE_ID, 'regionLink');
+      this.tileMirrorHorizontal = null;  
+      if (game.modules.get(fastFlipCompatiility.MODULE_ID)?.active){
+        this.tileMirrorHorizontal = placeable.object.document.getFlag(fastFlipCompatiility.MODULE_ID, fastFlipCompatiility.TILE_MIRROR_HORIZONTAL);
+      }
+    } else {
+      this.isNull = true;
+    }
+  }
+  // status checks
+  isFacing(){
+    let currentFacing = null;
+    if(this.type !== "Tile") return null;
+      switch(this.facing){
+      case 'south west':
+        currentFacing = this.isFlipped()? 'south east' : 'south west';
         break;
-      case "Tile-Token": // specific case requiring to pass the right type in the right order : Tile-Token
-        return sortByFacing(tile,token);
+      case 'south east':
+        currentFacing = this.isFlipped()? 'south west' : 'south east';
         break;
-      case "Token-Tile": // specific case requiring to pass the right type in the right order : Tile-Token
-        return sortByFacing(tile,token);
+      case 'south':
+        currentFacing = 'south';
         break;
-      case "Region-Sort": // regions override sorting on their linked itles
-        return isTile(sprite)? -100: 100; 
+      case 'side':
+        currentFacing = 'side';
         break;
       default:
-        return sortByFacing(sprite,sibling);
-        break;
+        currentFacing = null;
     }
+    return currentFacing;
+  }
+
+  isTile(){return this.type === "Tile";}
+  isToken(){return this.type === "Token";}
+  isNotNull(){return !this.isNull;}
+
+  isFlipped(){
+    let result = false;
+    if(this.tileMirrorHorizontal || this.tileFlipped){
+      result = true;
+    }
+    return result;
+  }
+
+  isRegionValid(){
+    let regionIsValid = true;
+    if(this.isToken()){
+      if(this.occupiedRegion === null || this.occupiedRegion === undefined || this.occupiedRegion === ""){ regionIsValid = false};
+    }
+    if(this.isTile()){
+      if(this.linkedRegion === null || this.linkedRegion === undefined || this.linkedRegion === ""){ regionIsValid = false};
+    }
+    return regionIsValid;
+  }
+  // sorting
+  getSortOrder(sibling){
+    let depthScore = 0;
+    if(this.isTile){
+      switch(this.isFacing()){ // evaluates cases based on which way the tile is facing in case its facing in a diagonal way
+        case 'south west':
+        depthScore = sibling.x - this.x;
+        break;
+      case 'south east': 
+        depthScore = sibling.y - this.y;
+        break;
+      default:
+        depthScore = Math.floor(( sibling.isoDepth - this.isoDepth ) * 0.5);
+      }
+    } else { // tokens dont care about facing
+      depthScore = Math.floor(( sibling.isoDepth - this.isoDepth ) * 0.5);
+    }
+    console.log(this.name, "sibling: " , sibling.name , depthScore)
+    return depthScore;
+  }
+  // debug
+  getDebugData(data){
+    const debugData = {}
+    for (const [key, value] of Object.entries(this)) {
+      data.map(entry => {
+        if(entry === key){
+          debugData[key] = value;
+        }
+      })
+    }
+    console.table(debugData);
   }
 }
 
-function sortByFacing(sprite,sibling){
-  let depthScore = {
-    isoDepth:0,
-    perpendicularDepth:0,
-  };
-  switch(getFacing(sprite)){ // evaluates cases based on which way the tile is facing
-    case 'south west':
-    depthScore.perpendicularDepth = sibling.x - sprite.x;
-    depthScore.isoDepth =  sprite.isoDepth - sibling.isoDepth;
-    break;
-  case 'south east': 
-    depthScore.perpendicularDepth = sprite.y - sibling.y;
-    depthScore.isoDepth =  sprite.isoDepth - sibling.isoDepth;
-    break;
-  default:
-    depthScore.perpendicularDepth = 0;
-    depthScore.isoDepth =  sprite.isoDepth - sibling.isoDepth;
-  }
-  return depthScore;
+///*** SortableSprite end *///
+
+// if needed can be moved in SortableSprite
+function switchPlaceablePositions(filteredLayer,sortScore){
+  const sprite = filteredLayer[sortScore.spriteIndex];
+  const sibling = filteredLayer[sortScore.siblingIndex];
+  filteredLayer[sortScore.spriteIndex] = sibling;
+  filteredLayer[sortScore.siblingIndex] = sprite;
 }
 
+// should be moved in SortableSprite
 function isRegionMatching (sprite, sibling){
   if(isDifferentId(sprite,sibling)){ // never compare an object against itself
     if(isRegionValid(sprite) && isRegionValid(sibling) || isRegionValid(sibling) && isRegionValid(sprite)){
@@ -235,41 +279,9 @@ function isRegionMatching (sprite, sibling){
   }
 }
 
+// could be moved in SortableSprite if needed
 function isDifferentId(spriteA,spriteB){
   return !(spriteA.id === spriteB.id)
-}
-
-// because javascript ... also help code readability.
-function isRegionValid(sprite){
-  let regionIsValid = true;
-  if(isToken(sprite)){
-    if(sprite.occupiedRegion === null || sprite.occupiedRegion === undefined || sprite.occupiedRegion === ""){ isValid = false};
-  }
-  if(isTile(sprite)){
-    if(sprite.linkedRegion === null || sprite.linkedRegion === undefined || sprite.linkedRegion === ""){ isValid = false};
-  }
-  return regionIsValid;
-}
-
-// compare cases where the placeable type is: 
-function comparePairings(sprite,sibling){
-  if(isToken(sprite) && isToken(sibling)){
-    return "Token-Token";
-  } else if(isTile(sprite) && isTile(sibling)){
-    return "Tile-Tile";
-  } else if(isTile(sprite) && isToken(sibling)){
-    if(isRegionMatching(sprite,sibling)){
-      return "Region-Sort";
-    } else {
-      return "Tile-Token";
-    }
-  } else if(isToken(sprite) && isTile(sibling)){
-    if(isRegionMatching(sprite,sibling)){
-      return "Region-Sort";
-    } else {
-      return "Token-Tile";
-    }
-  }
 }
 
 // Generic function to create adjustable buttons with drag functionality
@@ -398,6 +410,7 @@ export function toggleAnchorAxis(object,toggle){
   }
 }
 
+// dont know yet if should be moved in SortableSprite , keeping it external for now
 // used to debug visually a point on the tile selection box's footprint but its bugged, should fix later
 // IMPROVEMENT: draw the gizmo in a way to indicate which axis a tile is facing 
 // other improvement : instead of a drop down, two floating arrow buttons setting the facing that appear when the tile is controlled
@@ -444,151 +457,115 @@ function cleanupTileAnchorLines() {
   existingLines.forEach(line => line.destroy());
 };
 
-function isTile(sprite){
-  return sprite.type == "Tile";
-}
+// function isTile(sprite){
+//   return sprite.type == "Tile";
+// }
 
-function isToken(sprite){
-  return sprite.type == "Token";
-}
+// function isToken(sprite){
+//   return sprite.type == "Token";
+// }
 
-function isTileFlipped (sprite){
-  let result = false;
-  if(sprite.tileMirrorHorizontal || sprite.tileFlipped){
-    result = true;
-  }
-  return result;
-}
+// function isTileFlipped (sprite){
+//   let result = false;
+//   if(sprite.tileMirrorHorizontal || sprite.tileFlipped){
+//     result = true;
+//   }
+//   return result;
+// }
 
-// console.log("FLIPPED?", sprite.name , isTileFlipped(sprite), isTileFlipped(sprite)? 'south east' : 'south west') 
 
-//return a tile true facing in case the tile is in a flipped state if the initial facing is south west or south
-function getFacing(sprite) {
-  if(!isTile(sprite)) return null;
-  switch(sprite.tileFacing){
-    case 'south west':
-      return isTileFlipped(sprite)? 'south east' : 'south west';
-      break;
-    case 'south east':
-      return isTileFlipped(sprite)? 'south west' : 'south east';
-      break;
-    case 'south':
-      return 'south';
-      break;
-    case 'side':
-      return 'side';
-      break;
-    default:
-      return null;
-  }
-}
+// // compare cases where the placeable type is: 
+// function comparePairings(sprite,sibling){
+//   if(isToken(sprite) && isToken(sibling)){
+//     return "Token-Token";
+//   } else if(isTile(sprite) && isTile(sibling)){
+//     return "Tile-Tile";
+//   } else if(isTile(sprite) && isToken(sibling)){
+//     if(isRegionMatching(sprite,sibling)){
+//       return "Region-Sort";
+//     } else {
+//       return "Tile-Token";
+//     }
+//   } else if(isToken(sprite) && isTile(sibling)){
+//     if(isRegionMatching(sprite,sibling)){
+//       return "Region-Sort";
+//     } else {
+//       return "Token-Tile";
+//     }
+//   }
+// }
 
 /**
- * // a factory function that return a new object that contain all the relevant data required for depth sorting
- * // notes : turn that into a class later
- * @param {*} sprite 
- * @returns 
- */
+ * compare two placeables by Y positions if one of the placable is a tile that is flipped
+ * otherwise compare them by x positions.
+ * this is due to the X axis being a diagonal from bottom left to top right ( acending)
+ * an y being a diagonal from bottom riight to top left ( descending)
+ *  y-      +x
+ *    y-  x+
+ *      o
+ *    x-  y+
+ * x-        y+
+*/
+// compare a sprite and its sibling and return the right sorting score based on:
+// ... if both are tokens : sort by vertical depth
+// ... if both are tiles : sort by facing but the order dosent matter.
+// ... if one is a tile and the other a token sort by facing but the tile always go first
+// ... if the token and the tiles share a region ID , region override the sortscore and always put the tiles behind the token.
+// function getSortScore(sprite, sibling){
+//   // const token = isToken(sprite)? sprite : sibling;
+//   // const tile = isTile(sprite)? sprite : sibling;
+//   if(isDifferentId(sprite,sibling)){ // never compare an object against itself
+//     switch(comparePairings(sprite,sibling)){
+//       case "Token-Token": // order dosent matter.
+//       case "Tile-Tile": // order dosent matter, but the facing does.
+//       case "Tile-Token":
+//       case "Token-Tile":
+//         return sortByFacing(sprite,sibling);
+//         break;
+//       // case "Tile-Token": // specific case requiring to pass the right type in the right order : Tile-Token
+//       //   return sortByFacing(tile,token);
+//       //   break;
+//       // case "Token-Tile": // specific case requiring to pass the right type in the right order : Tile-Token
+//       //   return sortByFacing(tile,token);
+//       //   break;
+//       case "Region-Sort": // regions override sorting on their linked itles
+//         return isTile(sprite)? -100: 100; // need to change that to sort by region! 
+//         break;
+//       default:
+//         return sortByFacing(sprite,sibling);
+//         break;
+//     }
+//   }
+// }
 
-// may seems overkill but passing the values directly sometimes cause weird "in between" value mutations that bricks sorting calculations
-function sortableSprite(sprite){
-  const id = sprite.object.document.id;
-  const type = sprite.object.document.documentName;
-  const name = sprite.object.document.name? sprite.object.document.name : "no name";
-  const x = sprite.object.document.x;
-  const y = sprite.object.document.y;
-  let anchorX = sprite.object.document.x;
-  let anchorY = sprite.object.document.y;
-  let tileMirrorHorizontal = null;
-  const tileFacing = sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID, 'tileFacing') ?? DEFAULT_TILE_FACING;    
-  if (game.modules.get(fastFlipCompatiility.MODULE_ID)?.active){
-    tileMirrorHorizontal = sprite.object.document.getFlag(fastFlipCompatiility.MODULE_ID, fastFlipCompatiility.TILE_MIRROR_HORIZONTAL)
-  }
-  const tileFlipped = sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID, 'tileFlipped')?sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID,'tileFlipped') : null;
-  
-  const height = sprite.object.document.height;
-  const width = sprite.object.document.width;
-  let newLinkedRegion = sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID, 'regionLink');
-  let newOccupiedRegion = sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID, 'currentRegion');
+// token moving from front to behind its tile sibling will make perpendicularDepth go from - to +
+// tile moving from front to behind its tile sibling will make perpendicularDepth go from - to + but only for the sibling
 
-  return {
-    id:id,
-    type:type,
-    name: name,
-    x: x,
-    y: y,
-    isoDepth: y-x,
-    height:height,
-    width:width,
-    forceSortBelow: false,
-    forceSortAbove: false,
-    linkedRegion:newLinkedRegion,
-    occupiedRegion: newOccupiedRegion,
-    tileMirrorHorizontal: tileMirrorHorizontal,
-    tileFlipped: tileFlipped,
-    tileFacing:tileFacing,
-  }
-}
+// function sortByFacing(sprite,sibling){
+//   let depthScore = {
+//     isoDepth:0,
+//     perpendicularDepth:0,
+//   };
 
-function debugSort(sprite,sibling){
-  if(sprite.id !== sibling.id){
-    const data = {
-      sprite:{
-        value: sprite.name,
-        result: sprite.type,
-        facing: getFacing(sprite),
-      },
-      sibling:{
-        value: sibling.name,
-        result: sibling.type,
-        facing: getFacing(sibling),
-      },
-      sort:{
-        value: sortByFacing(sprite, sibling)
-      }
-    };
-    console.table(data);
-  }
-}
+//   switch(sprite.isFacing()){ // evaluates cases based on which way the tile is facing
+//     case 'south west':
+//     depthScore.perpendicularDepth = sprite.x - sibling.x;
+//     depthScore.isoDepth =  Math.floor(( sprite.isoDepth - sibling.isoDepth ) * 0.5); // token moving from front to behind go from - to + but positive should mean in front while negative should mean behind
+//     break;
+//   case 'south east': 
+//     depthScore.perpendicularDepth = sprite.y - sibling.y;
+//     depthScore.isoDepth =  Math.floor(( sprite.isoDepth - sibling.isoDepth ) * 0.5); // token moving from front to behind go from - to + but positive should mean in front while negative should mean behind
+//     break;
+//   default:
+//     depthScore.perpendicularDepth = 0;
+//     depthScore.isoDepth = Math.floor(( sprite.isoDepth - sibling.isoDepth ) * 0.5);
+//   }
 
-// for debugging canvasLayers 
-export function debugCanvasLayer(spriteList){
-    const data = [];
+//   return depthScore;
+// }
 
-    spriteList.map(sprite => {
-      let newLinkedRegion = sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID, 'regionLink');
-      let newOccupiedRegion = sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID, 'currentRegion');
-      if(!newLinkedRegion){newLinkedRegion = null;}
-      if(!newOccupiedRegion){newOccupiedRegion = null;}
-      let tileMirrorHorizontal = null;
-      const tileFacing = sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID, 'tileFacing') ?? DEFAULT_TILE_FACING;
-      if (game.modules.get(fastFlipCompatiility.MODULE_ID)?.active){
-        tileMirrorHorizontal = sprite.object.document.getFlag(fastFlipCompatiility.MODULE_ID, fastFlipCompatiility.TILE_MIRROR_HORIZONTAL)
-      }
-      const tileFlipped = sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID, 'tileFlipped')?sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID,'tileFlipped') : null; 
-      const trueFacing = getFacing({
-        type: sprite.object.document.documentName,
-        tileFacing: tileFacing,
-        tileFlipped: tileFlipped,
-        tileMirrorHorizontal:tileMirrorHorizontal
-      })
 
-      data.push({
-        // id: sprite.object.document.id,
-        // type: sprite.object.document.documentName,
-        name: sprite.object.document.name? sprite.object.document.name : "no name",
-        //sprite.documentName === "Tile"? (sprite.x) - (sprite.width *0.25) : sprite.x,
-        // x: sprite.object.document.x,
-        // y: sprite.object.document.y,
-        // sortLayer: sprite.sortLayer, 
-        // sort: sprite.sort,
-        // linkedRegion:newLinkedRegion,
-        // occupiedRegion: newOccupiedRegion,
-        // tileMirrorHorizontal: sprite.object.document.getFlag(fastFlipCompatiility.MODULE_ID, fastFlipCompatiility.TILE_MIRROR_HORIZONTAL)?sprite.object.document.getFlag(fastFlipCompatiility.MODULE_ID, fastFlipCompatiility.TILE_MIRROR_HORIZONTAL) : null,
-        // tileFlipped: sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID, 'tileFlipped')?sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID,'tileFlipped') : null,
-        // tileFacing: tileFacing,
-        // trueFacing : trueFacing
-      })
-    });
-    console.table(data)
-}
+// // cant figure out if this priority order is correct or not, the distribution of placeables is correct but their ordering is still incorrect
+// function sortLayerByDepth(sprite,sibling){ 
+//   return sprite.isoDepth - sibling.isoDepth;
+// }

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -114,33 +114,27 @@ export function patchConfig(documentSheet, config, args) {
 }
 
 // filter the sort layer into a new array of sortables, copy that array , sort the copy and return the result.
-export function sortPlaceableByPosition(placeable) { // might not need palceable later
-  console.clear()
+export function sortPlaceableByPosition() { // might not need palceable later
   const placeableMeshLayer = foundry.canvas.groups.PrimaryCanvasGroup.SORT_LAYERS.TOKENS;
   const canvasLayer = canvas.primary.children;
 
   const filteredLayer = canvasLayer.filter( sprite => {
-    return sprite.sortLayer === placeableMeshLayer && sprite.object.previewType === null;
+    return sprite.sortLayer === placeableMeshLayer;
   }); // only need DepthSortPlaceables
-  // let layerToSort = filteredLayer.map(item => Object.assign({}, item));
-  let layerToSort = filteredLayer.map(item => Object.assign({}, item)).reverse();
+  let layerToSort = filteredLayer.map(item => Object.assign({}, item)) //.reverse();
 
-  layerToSort = layerToSort.toSorted((sprite,sibling) => {
+  layerToSort.sort((sprite,sibling) => {
     const currentSprite = new SortableSprite(sprite);
     const currentSibling = new SortableSprite(sibling);
     return currentSprite.getSortOrder(currentSibling)
-  });
+  }).reverse();
 
-  // might delete later
-  // for(let i = 0; i < layerToSort.length; i++){
-  //   const current = new SortableSprite(layerToSort[i]);
-  //   const next = new SortableSprite(layerToSort[i+1]);
-  //   if(current.isToken() && next.isNotNull()){
-  //     const sortScore = sortByFacing(next,current);
-  //     // console.log("IS TOKEN?", current.name , next.name , sortScore)
-  //   }
-  // }
-  
+  // keep for debugging later
+  // layerToSort.map(sprite => {
+  //   const currentSprite = new SortableSprite(sprite);
+  //   currentSprite.getDebugData(["name","sort","facing"])
+  // })
+
   return layerToSort;
 }
 
@@ -174,6 +168,7 @@ export class SortableSprite {
       this.occupiedRegion = placeable.object.document.getFlag(isometricModuleConfig.MODULE_ID, 'currentRegion');
       this.linkedRegion = placeable.object.document.getFlag(isometricModuleConfig.MODULE_ID, 'regionLink');
       this.tileMirrorHorizontal = null;  
+      this.preview = placeable.object.previewType;
       if (game.modules.get(fastFlipCompatiility.MODULE_ID)?.active){
         this.tileMirrorHorizontal = placeable.object.document.getFlag(fastFlipCompatiility.MODULE_ID, fastFlipCompatiility.TILE_MIRROR_HORIZONTAL);
       }
@@ -207,7 +202,7 @@ export class SortableSprite {
   isTile(){return this.type === "Tile";}
   isToken(){return this.type === "Token";}
   isNotNull(){return !this.isNull;}
-
+  isPreview(){return this.preview !== null}
   isFlipped(){
     let result = false;
     if(this.tileMirrorHorizontal || this.tileFlipped){
@@ -229,21 +224,28 @@ export class SortableSprite {
   // sorting
   getSortOrder(sibling){
     let depthScore = 0;
-    if(this.isTile){
+    // need to find a way to write this in a easier to read fashion , and find a way to make the sorting do exactly what its meant to
+    // the flicker is happening because at some other point in the sort loop , the same operation is reverted back
+    // need to find why
+    if(this.isTile && sibling.isToken()){
       switch(this.isFacing()){ // evaluates cases based on which way the tile is facing in case its facing in a diagonal way
         case 'south west':
-        depthScore = sibling.x - this.x;
-        break;
-      case 'south east': 
-        depthScore = sibling.y - this.y;
-        break;
-      default:
-        depthScore = Math.floor(( sibling.isoDepth - this.isoDepth ) * 0.5);
+          depthScore = sibling.x - this.x;
+          break;
+        case 'south east':
+          depthScore = this.y - sibling.y;
+          break;
+        default:
+          // depthScore = Math.floor(( this.isoDepth - sibling.isoDepth ) * 0.5);
+          depthScore = Math.floor(( sibling.isoDepth - this.isoDepth ) * 0.5);
+          break;
       }
-    } else { // tokens dont care about facing
-      depthScore = Math.floor(( sibling.isoDepth - this.isoDepth ) * 0.5);
+    } else if(this.isToken() && sibling.isTile()){ // letting the tile sibling deal with the sorting the same way seems to prevent result asymmetry 
+      depthScore = sibling.getSortOrder(this);// but also make sure its always the tile who does the sorting the same way in all cases
+    } else {
+      // depthScore = Math.floor((this.isoDepth - sibling.isoDepth ) * 0.5);
+      depthScore = Math.floor((sibling.isoDepth - this.isoDepth ) * 0.5);
     }
-    console.log(this.name, "sibling: " , sibling.name , depthScore)
     return depthScore;
   }
   // debug
@@ -456,116 +458,3 @@ function cleanupTileAnchorLines() {
   const existingLines = canvas.stage.children.filter(child => child.name === 'anchorLine');
   existingLines.forEach(line => line.destroy());
 };
-
-// function isTile(sprite){
-//   return sprite.type == "Tile";
-// }
-
-// function isToken(sprite){
-//   return sprite.type == "Token";
-// }
-
-// function isTileFlipped (sprite){
-//   let result = false;
-//   if(sprite.tileMirrorHorizontal || sprite.tileFlipped){
-//     result = true;
-//   }
-//   return result;
-// }
-
-
-// // compare cases where the placeable type is: 
-// function comparePairings(sprite,sibling){
-//   if(isToken(sprite) && isToken(sibling)){
-//     return "Token-Token";
-//   } else if(isTile(sprite) && isTile(sibling)){
-//     return "Tile-Tile";
-//   } else if(isTile(sprite) && isToken(sibling)){
-//     if(isRegionMatching(sprite,sibling)){
-//       return "Region-Sort";
-//     } else {
-//       return "Tile-Token";
-//     }
-//   } else if(isToken(sprite) && isTile(sibling)){
-//     if(isRegionMatching(sprite,sibling)){
-//       return "Region-Sort";
-//     } else {
-//       return "Token-Tile";
-//     }
-//   }
-// }
-
-/**
- * compare two placeables by Y positions if one of the placable is a tile that is flipped
- * otherwise compare them by x positions.
- * this is due to the X axis being a diagonal from bottom left to top right ( acending)
- * an y being a diagonal from bottom riight to top left ( descending)
- *  y-      +x
- *    y-  x+
- *      o
- *    x-  y+
- * x-        y+
-*/
-// compare a sprite and its sibling and return the right sorting score based on:
-// ... if both are tokens : sort by vertical depth
-// ... if both are tiles : sort by facing but the order dosent matter.
-// ... if one is a tile and the other a token sort by facing but the tile always go first
-// ... if the token and the tiles share a region ID , region override the sortscore and always put the tiles behind the token.
-// function getSortScore(sprite, sibling){
-//   // const token = isToken(sprite)? sprite : sibling;
-//   // const tile = isTile(sprite)? sprite : sibling;
-//   if(isDifferentId(sprite,sibling)){ // never compare an object against itself
-//     switch(comparePairings(sprite,sibling)){
-//       case "Token-Token": // order dosent matter.
-//       case "Tile-Tile": // order dosent matter, but the facing does.
-//       case "Tile-Token":
-//       case "Token-Tile":
-//         return sortByFacing(sprite,sibling);
-//         break;
-//       // case "Tile-Token": // specific case requiring to pass the right type in the right order : Tile-Token
-//       //   return sortByFacing(tile,token);
-//       //   break;
-//       // case "Token-Tile": // specific case requiring to pass the right type in the right order : Tile-Token
-//       //   return sortByFacing(tile,token);
-//       //   break;
-//       case "Region-Sort": // regions override sorting on their linked itles
-//         return isTile(sprite)? -100: 100; // need to change that to sort by region! 
-//         break;
-//       default:
-//         return sortByFacing(sprite,sibling);
-//         break;
-//     }
-//   }
-// }
-
-// token moving from front to behind its tile sibling will make perpendicularDepth go from - to +
-// tile moving from front to behind its tile sibling will make perpendicularDepth go from - to + but only for the sibling
-
-// function sortByFacing(sprite,sibling){
-//   let depthScore = {
-//     isoDepth:0,
-//     perpendicularDepth:0,
-//   };
-
-//   switch(sprite.isFacing()){ // evaluates cases based on which way the tile is facing
-//     case 'south west':
-//     depthScore.perpendicularDepth = sprite.x - sibling.x;
-//     depthScore.isoDepth =  Math.floor(( sprite.isoDepth - sibling.isoDepth ) * 0.5); // token moving from front to behind go from - to + but positive should mean in front while negative should mean behind
-//     break;
-//   case 'south east': 
-//     depthScore.perpendicularDepth = sprite.y - sibling.y;
-//     depthScore.isoDepth =  Math.floor(( sprite.isoDepth - sibling.isoDepth ) * 0.5); // token moving from front to behind go from - to + but positive should mean in front while negative should mean behind
-//     break;
-//   default:
-//     depthScore.perpendicularDepth = 0;
-//     depthScore.isoDepth = Math.floor(( sprite.isoDepth - sibling.isoDepth ) * 0.5);
-//   }
-
-//   return depthScore;
-// }
-
-
-// // cant figure out if this priority order is correct or not, the distribution of placeables is correct but their ordering is still incorrect
-// function sortLayerByDepth(sprite,sibling){ 
-//   return sprite.isoDepth - sibling.isoDepth;
-// }

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -139,13 +139,30 @@ export function sortPlaceableByRegion(placeable) {
  * change placeables sort values based on its y value on the grid compared to its siblings.
  * @param {Placeable|PlaceableDocument} placeable - The placeable document used as a reference for the sortlayer.
  */
-export function sortPlaceableByPosition() {
+export function sortPlaceableByPosition(placeable) {
   const placeableMeshLayer = foundry.canvas.groups.PrimaryCanvasGroup.SORT_LAYERS.TOKENS;
   const canvasLayer = canvas.primary.children;
   const currentSortLayer = canvas.primary;
-  return canvasLayer.filter( sprite => sprite.sortLayer === placeableMeshLayer)
-  .sort((sprite,sibling)=> compareSiblingPosition(sprite,sibling))
-  .toSorted((sprite,sibling)=> compareSiblingPosition(sprite,sibling));
+
+  const sortList = [];
+  const filteredLayer = canvasLayer.filter( sprite => sprite.sortLayer === placeableMeshLayer)
+  // .map( sprite => {
+  for (let i = 0; i < filteredLayer.length; i++) {
+    if(placeable){
+      const currentSprite = sortableSprite(placeable.mesh);
+      const currentSibling = sortableSprite(filteredLayer[i]);
+      const sortScore = getSortScore(currentSprite,currentSibling);
+      console.log("sortScore", currentSibling.name, sortScore)
+      sortList.push({sibling:sprite, sortScore:sortScore});
+    }
+  }
+
+  // so now i got two depth score and i must sort the array by taking in account first the isoDepth
+  // then the perpendicularDepth if its not 0
+  // a depth score that is positive mean sorted above, negative means sorted below
+
+  // probably mean i got to sort twice ... 
+
 }
 
 /**
@@ -159,90 +176,101 @@ export function sortPlaceableByPosition() {
  *    x-  y+
  * x-        y+
 */
-
-function compareSiblingPosition(sprite,sibling){    
-  let sortChange = 0;
-  const currentSprite = sortableSprite(sprite);
-  const currentSibling = sortableSprite(sibling);
-  // for cases with tiles linked to a region with region sort enabled.
-  if(isRegionMatching(currentSprite,currentSibling)){
-    sortChange = sortByRegion(currentSprite,currentSibling);
-  } else {
-    // debugSort(currentSprite,currentSibling)
-    sortChange = sortByFacing(currentSprite,currentSibling);
+// compare a sprite and its sibling and return the right sorting score based on:
+// ... if both are tokens : sort by vertical depth
+// ... if both are tiles : sort by facing but the order dosent matter.
+// ... if one is a tile and the other a token sort by facing but the tile always go first
+// ... if the token and the tiles share a region ID , region override the sortscore and always put the tiles behind the token.
+function getSortScore(sprite, sibling){
+  const token = isToken(sprite)? sprite : sibling;
+  const tile = isTile(sprite)? sprite : sibling;
+  if(isDifferentId(sprite,sibling)){ // never compare an object against itself
+    switch(comparePairings(sprite,sibling)){
+      case "Token-Token": // order dosent matter.
+      case "Tile-Tile": // order dosent matter, but the facing does.
+        return sortByFacing(sprite,sibling);
+        break;
+      case "Tile-Token": // specific case requiring to pass the right type in the right order : Tile-Token
+        return sortByFacing(tile,token);
+        break;
+      case "Token-Tile": // specific case requiring to pass the right type in the right order : Tile-Token
+        return sortByFacing(tile,token);
+        break;
+      case "Region-Sort": // regions override sorting on their linked itles
+        return isTile(sprite)? -100: 100; 
+        break;
+      default:
+        return sortByFacing(sprite,sibling);
+        break;
+    }
   }
-  return sortChange;
+}
+
+function sortByFacing(sprite,sibling){
+  let depthScore = {
+    isoDepth:0,
+    perpendicularDepth:0,
+  };
+  switch(getFacing(sprite)){ // evaluates cases based on which way the tile is facing
+    case 'south west':
+    depthScore.perpendicularDepth = sibling.x - sprite.x;
+    depthScore.isoDepth =  sprite.isoDepth - sibling.isoDepth;
+    break;
+  case 'south east': 
+    depthScore.perpendicularDepth = sprite.y - sibling.y;
+    depthScore.isoDepth =  sprite.isoDepth - sibling.isoDepth;
+    break;
+  default:
+    depthScore.perpendicularDepth = 0;
+    depthScore.isoDepth =  sprite.isoDepth - sibling.isoDepth;
+  }
+  return depthScore;
+}
+
+function isRegionMatching (sprite, sibling){
+  if(isDifferentId(sprite,sibling)){ // never compare an object against itself
+    if(isRegionValid(sprite) && isRegionValid(sibling) || isRegionValid(sibling) && isRegionValid(sprite)){
+      if(sprite.occupiedRegion === sibling.linkedRegion || sibling.occupiedRegion === sprite.linkedRegion){ return true; }
+    } else { return false;}
+  }
+}
+
+function isDifferentId(spriteA,spriteB){
+  return !(spriteA.id === spriteB.id)
+}
+
+// because javascript ... also help code readability.
+function isRegionValid(sprite){
+  let regionIsValid = true;
+  if(isToken(sprite)){
+    if(sprite.occupiedRegion === null || sprite.occupiedRegion === undefined || sprite.occupiedRegion === ""){ isValid = false};
+  }
+  if(isTile(sprite)){
+    if(sprite.linkedRegion === null || sprite.linkedRegion === undefined || sprite.linkedRegion === ""){ isValid = false};
+  }
+  return regionIsValid;
 }
 
 // compare cases where the placeable type is: 
-// token vs token
-// tile vs tile 
-// token vs tile
-// avoid cluttering getSortingRule() and improve code readability
 function comparePairings(sprite,sibling){
   if(isToken(sprite) && isToken(sibling)){
     return "Token-Token";
   } else if(isTile(sprite) && isTile(sibling)){
     return "Tile-Tile";
   } else if(isTile(sprite) && isToken(sibling)){
-    return "Tile-Token";
+    if(isRegionMatching(sprite,sibling)){
+      return "Region-Sort";
+    } else {
+      return "Tile-Token";
+    }
   } else if(isToken(sprite) && isTile(sibling)){
-    return "Token-Tile";
-  }
-}
-
-// compare a sprite and its sibling and return the right sorting rule based on:
-// ... if the sibling is a token : sort by vertical depth --done 
-// ... if the sibling is a token inside a region with linked walls : sort the linked walls behind the token -- todo
-// ... if the sibling is a tile : compare depth based on their facing and if they are flipped -- wip
-//     ... if a sibling is  a tile and is facing south west , sort on the y axis
-//     ... if a sibling is  a tile and is facing south east , sort on the x axis
-function sortByFacing(spriteToSort, siblingToCompare){
-  if(spriteToSort.id !== siblingToCompare.id){ // never compare an object against itself
-    switch(comparePairings(spriteToSort,siblingToCompare)){
-      case "Token-Token":
-        // tokens are always sorted by x/y depth against each others
-        return spriteToSort.isoDepth - siblingToCompare.isoDepth; // other cases dont need complex rules, simply compare by vertical position on the screen
-        break;
-      case "Tile-Tile":
-      case "Tile-Token":
-      case "Token-Tile":
-        // tiles have a bit more complex logic , especially if they have a large width, so tiles are compared by a perpendicular X axis or Y axis
-        // this take in account a tile facing and if its flipped , 
-        switch(getFacing(siblingToCompare)){ 
-          case 'south west':
-            return siblingToCompare.x - spriteToSort.x 
-            break;
-          case 'south east':
-            return spriteToSort.y - siblingToCompare.y 
-            break;
-          default:
-            return spriteToSort.isoDepth - siblingToCompare.isoDepth; 
-        }
-        break;
-      default:
-        return spriteToSort.isoDepth - siblingToCompare.isoDepth; 
-        break;
+    if(isRegionMatching(sprite,sibling)){
+      return "Region-Sort";
+    } else {
+      return "Token-Tile";
     }
   }
 }
-
-function sortByRegion(sprite, sibling){
-  if(isTile(sprite)){
-    return -1;
-  } else if (isTile(sibling)){
-    return 1;
-  }
-}
-
-function isRegionMatching (sprite, sibling){
-  if(sprite.occupiedRegion !== null && sibling.linkedRegion !== null){
-    if(sprite.occupiedRegion === sibling.linkedRegion){ return true }
-  } else if(sibling.occupiedRegion !== null && sprite.linkedRegion !== null){
-    if(sibling.occupiedRegion === sprite.linkedRegion){ return true }
-  } else { return false; }
-}
-
 
 // Generic function to create adjustable buttons with drag functionality
 export function createAdjustableButton(options) {
@@ -416,7 +444,6 @@ function cleanupTileAnchorLines() {
   existingLines.forEach(line => line.destroy());
 };
 
-
 function isTile(sprite){
   return sprite.type == "Tile";
 }
@@ -483,8 +510,6 @@ function sortableSprite(sprite){
   const width = sprite.object.document.width;
   let newLinkedRegion = sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID, 'regionLink');
   let newOccupiedRegion = sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID, 'currentRegion');
-  if(!newLinkedRegion){newLinkedRegion = null};
-  if(!newOccupiedRegion){newOccupiedRegion = null};
 
   return {
     id:id,
@@ -553,17 +578,16 @@ export function debugCanvasLayer(spriteList){
         // type: sprite.object.document.documentName,
         name: sprite.object.document.name? sprite.object.document.name : "no name",
         //sprite.documentName === "Tile"? (sprite.x) - (sprite.width *0.25) : sprite.x,
-        x: sprite.object.document.x,
-        y: sprite.object.document.y,
+        // x: sprite.object.document.x,
+        // y: sprite.object.document.y,
         // sortLayer: sprite.sortLayer, 
-        sort: sprite.sort,
+        // sort: sprite.sort,
         // linkedRegion:newLinkedRegion,
         // occupiedRegion: newOccupiedRegion,
-        // occupiedRegion: sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID, 'currentRegion')? sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID, 'currentRegion') : "none",
         // tileMirrorHorizontal: sprite.object.document.getFlag(fastFlipCompatiility.MODULE_ID, fastFlipCompatiility.TILE_MIRROR_HORIZONTAL)?sprite.object.document.getFlag(fastFlipCompatiility.MODULE_ID, fastFlipCompatiility.TILE_MIRROR_HORIZONTAL) : null,
         // tileFlipped: sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID, 'tileFlipped')?sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID,'tileFlipped') : null,
         // tileFacing: tileFacing,
-        trueFacing : trueFacing
+        // trueFacing : trueFacing
       })
     });
     console.table(data)


### PR DESCRIPTION
good progress , the basic depth sorting is now much better but occasional tile or token flickering still happens

-  possible reasons : the animation updates may have a conflicting overlap with the sorting 
-  foundry own's sorting logic could be conflicting with depth sorting

at least , the sorting logic is no longer causing asymmetrical changes that revert back and forth every sorting pass
and the current state of a depth sorted scene is good enough to be playable 

whats next : investigate the flicker issues futher 
polish the UI and add isometric features like flip, anchor offset in the tile palette.

polish the gizmo to display which way a tile is facing. maybe also add some floating buttons to flip a tile via the gizmo.